### PR TITLE
feat: extract card limit and best purchase day from invoices

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -47,7 +47,6 @@ from app.services.onboarding import (
     BUDGET_SETUP_PENDING,
     CARD_COUNT_PENDING,
     COST_REVIEW_PENDING,
-    CARD_DETAILS_PENDING,
     CARD_INVOICE_PENDING,
     CARD_NAMES_PENDING,
     DOCUMENT_ONBOARDING_PENDING,
@@ -57,7 +56,6 @@ from app.services.onboarding import (
     ONBOARDING_COMPLETE,
     account_snapshot_prompt,
     card_count_prompt,
-    card_details_prompt,
     card_invoice_prompt,
     card_names_prompt,
     cost_review_adjustment_prompt,
@@ -73,10 +71,8 @@ from app.services.onboarding import (
     is_cost_review_completed,
     parse_card_count,
     parse_card_names_llm_first,
-    parse_card_details_message,
     parse_balance_message,
     parse_cost_review_adjustments,
-    save_current_card_details,
     save_card_count,
     save_cost_candidates,
     save_card_names,
@@ -456,11 +452,11 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
             if card_names:
                 save_card_names(user_id, card_names)
                 set_pending_card_index(user_id, 0)
-                set_onboarding_state(user_id, CARD_DETAILS_PENDING)
+                set_onboarding_state(user_id, CARD_INVOICE_PENDING)
                 confirmed_names = get_card_names(user_id) or card_names
                 resposta = (
                     f"{build_card_setup_confirmation(confirmed_names)}\n\n"
-                    f"{card_details_prompt(confirmed_names[0])}"
+                    f"{card_invoice_prompt(confirmed_names[0])}"
                 )
                 return Response(content=build_twiml(resposta), media_type="application/xml")
 
@@ -475,72 +471,6 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
             resposta = (
                 "Tive um problema para salvar os nomes dos seus cartoes agora. "
                 "Se puder, tente me mandar os nomes novamente separados por virgula."
-            )
-            return Response(content=build_twiml(resposta), media_type="application/xml")
-
-    if onboarding_state == CARD_DETAILS_PENDING:
-        try:
-            current_card = get_current_card(user_id)
-            if not current_card:
-                set_pending_card_index(user_id, 0)
-                set_onboarding_state(user_id, CARD_INVOICE_PENDING)
-                resposta = document_upload_prompt(user_id)
-                return Response(content=build_twiml(resposta), media_type="application/xml")
-
-            if should_skip_card_setup(mensagem):
-                next_card = advance_card_progress(user_id)
-                if next_card:
-                    resposta = (
-                        f"Tudo bem. A gente pode preencher esses detalhes do {current_card['nome_cartao']} depois.\n\n"
-                        f"{card_details_prompt(str(next_card['nome_cartao']))}"
-                    )
-                else:
-                    set_pending_card_index(user_id, 0)
-                    set_onboarding_state(user_id, CARD_INVOICE_PENDING)
-                    resposta = (
-                        "Tudo bem. Se precisar, a gente completa esses detalhes de compra mais tarde.\n\n"
-                        f"{document_upload_prompt(user_id)}"
-                    )
-                return Response(content=build_twiml(resposta), media_type="application/xml")
-
-            best_day, limit_value = parse_card_details_message(mensagem)
-            if best_day is not None or limit_value is not None:
-                updated_card = save_current_card_details(user_id, best_day, limit_value) or current_card
-                next_card = advance_card_progress(user_id)
-                detail_parts = []
-                if updated_card.get("dia_melhor_compra"):
-                    detail_parts.append(f"melhor dia {updated_card['dia_melhor_compra']}")
-                if updated_card.get("limite_credito") is not None:
-                    detail_parts.append(f"limite de R${float(updated_card['limite_credito']):.2f}")
-                detail_summary = ", ".join(detail_parts) if detail_parts else "essas informacoes"
-
-                if next_card:
-                    resposta = (
-                        f"Perfeito. Ja anotei {detail_summary} para o {updated_card['nome_cartao']}.\n\n"
-                        f"{card_details_prompt(str(next_card['nome_cartao']))}"
-                    )
-                else:
-                    set_pending_card_index(user_id, 0)
-                    set_onboarding_state(user_id, CARD_INVOICE_PENDING)
-                    resposta = (
-                        f"Perfeito. Ja anotei {detail_summary} para o {updated_card['nome_cartao']}.\n\n"
-                        f"{document_upload_prompt(user_id)}"
-                    )
-                return Response(content=build_twiml(resposta), media_type="application/xml")
-
-            resposta = (
-                f"Quero deixar o {current_card['nome_cartao']} bem configurado desde o inicio.\n\n"
-                f"{card_details_prompt(str(current_card['nome_cartao']))}"
-            )
-            return Response(content=build_twiml(resposta), media_type="application/xml")
-        except HTTPException as exc:
-            return Response(content=build_twiml(exc.detail), media_type="application/xml")
-        except Exception:
-            current_card = get_current_card(user_id)
-            fallback_name = current_card["nome_cartao"] if current_card else "esse cartao"
-            resposta = (
-                f"Tive um problema para salvar os detalhes do {fallback_name} agora.\n\n"
-                f"{card_details_prompt(str(fallback_name))}"
             )
             return Response(content=build_twiml(resposta), media_type="application/xml")
 

--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -786,6 +786,8 @@ def _extract_document_analysis(
         '"minimum_payment":numero ou null,'
         '"due_date":"YYYY-MM-DD" ou null,'
         '"issuer":"texto" ou null,'
+        '"credit_limit":numero ou null,'
+        '"best_purchase_day":numero inteiro entre 1 e 31 ou null,'
         '"detected_income":numero ou null,'
         '"income_description":"texto" ou null,'
         '"income_confidence":"high|medium|low" ou null,'
@@ -794,7 +796,10 @@ def _extract_document_analysis(
         '"credit_entries":[{"date":"YYYY-MM-DD ou texto","description":"texto","amount":numero}],'
         '"debit_entries":[{"date":"YYYY-MM-DD ou texto","description":"texto","amount":numero}],'
         '"estimated_fixed_expenses":numero ou null,'
-        '"top_items":["item 1","item 2"]}'
+        '"top_items":["item 1","item 2"]}. '
+        "Para faturas de cartao: credit_limit e o limite total do cartao (campo 'limite', 'limite do cartao' ou similar). "
+        "best_purchase_day e o melhor dia para compras (campo 'melhor dia para compras', 'data de fechamento' menos alguns dias, ou similar). "
+        "Se nao estiver explicito, retorne null."
     )
 
     if media_content_type == "application/pdf":
@@ -943,6 +948,29 @@ def _persist_financial_context(user_id: int, analysis: dict[str, Any], card_id: 
                 (user_id, card_id, invoice_total, due_date or "", minimum_payment, issuer),
             )
 
+        if document_type == "fatura_cartao" and card_id is not None:
+            credit_limit = _safe_float(analysis.get("credit_limit"))
+            best_purchase_day_raw = analysis.get("best_purchase_day")
+            best_purchase_day = None
+            if best_purchase_day_raw is not None:
+                try:
+                    day = int(best_purchase_day_raw)
+                    if 1 <= day <= 31:
+                        best_purchase_day = day
+                except (TypeError, ValueError):
+                    pass
+
+            if credit_limit is not None or best_purchase_day is not None:
+                cursor.execute(
+                    """
+                    UPDATE cartoes_usuario
+                    SET dia_melhor_compra = COALESCE(%s, dia_melhor_compra),
+                        limite_credito    = COALESCE(%s, limite_credito)
+                    WHERE id = %s
+                    """,
+                    (best_purchase_day, credit_limit, card_id),
+                )
+
         conn.commit()
 
 
@@ -996,11 +1024,23 @@ def _build_analysis_message(analysis: dict[str, Any], fallback_type: str) -> str
     elif document_type == "fatura_cartao":
         lines.append("Recebi sua fatura e ja extraí alguns dados importantes.")
         if invoice_total is not None:
-            lines.append(f"- valor total da fatura: R${invoice_total:.2f}")
+            lines.append(f"- valor total da fatura: {format_brl(invoice_total)}")
         if due_date:
-            lines.append(f"- vencimento identificado: {due_date}")
+            formatted_due = format_ptbr_date(due_date) or due_date
+            lines.append(f"- vencimento: {formatted_due}")
         if minimum_payment is not None:
-            lines.append(f"- pagamento minimo: R${minimum_payment:.2f}")
+            lines.append(f"- pagamento minimo: {format_brl(minimum_payment)}")
+        credit_limit = _safe_float(analysis.get("credit_limit"))
+        if credit_limit is not None:
+            lines.append(f"- limite do cartao: {format_brl(credit_limit)}")
+        best_purchase_day_raw = analysis.get("best_purchase_day")
+        if best_purchase_day_raw is not None:
+            try:
+                day = int(best_purchase_day_raw)
+                if 1 <= day <= 31:
+                    lines.append(f"- melhor dia para compras: dia {day}")
+            except (TypeError, ValueError):
+                pass
     else:
         lines.append("Recebi seu documento financeiro e consegui registrar algumas informacoes iniciais.")
 


### PR DESCRIPTION
## Summary

- Remove a etapa `CARD_DETAILS_PENDING` do onboarding, que perguntava manualmente ao usuário o limite e o melhor dia de compra de cada cartão
- Esses dados agora são extraídos automaticamente da fatura enviada pelo usuário via GPT vision (PDF ou imagem)
- O campo `credit_limit` e `best_purchase_day` foram adicionados ao schema JSON do prompt de análise de documentos
- `_persist_financial_context` persiste os valores em `cartoes_usuario` usando `COALESCE`, preservando valores pré-existentes
- A resposta ao usuário após o envio da fatura exibe o limite e o melhor dia encontrados

Fixes #15
Fixes #16

## Test plan

- [ ] Usuário envia fatura durante onboarding: verificar que `dia_melhor_compra` e `limite_credito` são preenchidos em `cartoes_usuario`
- [ ] Fatura sem campo de limite: verificar que os campos permanecem `null` sem erro
- [ ] Fatura com campos presentes: verificar que a resposta exibe "- limite do cartao: R$X" e "- melhor dia para compras: dia Y"
- [ ] Onboarding completo: verificar que o fluxo vai de `CARD_NAMES_PENDING` direto para `CARD_INVOICE_PENDING`, sem parar em `CARD_DETAILS_PENDING`

🤖 Generated with [Claude Code](https://claude.com/claude-code)