### PR TITLE
feat: voice message support via Whisper transcription (#28)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -47,6 +47,7 @@ from app.services.documents import (
     start_document_onboarding,
 )
 from app.services.financial_health import build_financial_health_message
+from app.services.voice import is_audio_media, transcribe_audio
 from app.services.onboarding import (
     ACCOUNT_SNAPSHOT_PENDING,
     BUDGET_SETUP_PENDING,
@@ -141,6 +142,23 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
     mensagem = (form.get("Body") or "").strip()
     numero = (form.get("From") or "").strip()
     incoming_media = get_incoming_media(form)
+
+    # Transcreve áudio (mensagens de voz do WhatsApp) antes do processamento normal
+    if incoming_media:
+        _, media_content_type = incoming_media
+        if is_audio_media(media_content_type):
+            transcript = transcribe_audio(incoming_media[0])
+            if transcript:
+                mensagem = transcript
+                incoming_media = None
+            else:
+                return Response(
+                    content=build_twiml(
+                        "Recebi seu áudio, mas não consegui transcrever agora. "
+                        "Se puder, tente enviar a mensagem por texto."
+                    ),
+                    media_type="application/xml",
+                )
 
     if not numero:
         return Response(

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1,0 +1,56 @@
+import io
+
+import requests
+from openai import OpenAI
+
+from app.config import get_settings
+from app.services.logger import get_logger
+
+logger = get_logger("navi.voice")
+
+SUPPORTED_AUDIO_TYPES = {
+    "audio/ogg",
+    "audio/ogg; codecs=opus",
+    "audio/mpeg",
+    "audio/mp4",
+    "audio/wav",
+    "audio/webm",
+    "audio/amr",
+}
+
+
+def is_audio_media(content_type: str) -> bool:
+    return content_type.split(";")[0].strip() in SUPPORTED_AUDIO_TYPES or content_type.startswith("audio/")
+
+
+def transcribe_audio(media_url: str) -> str | None:
+    settings = get_settings()
+    if not settings.openai_api_key:
+        logger.warning("transcribe_audio skipped: OPENAI_API_KEY not set")
+        return None
+
+    try:
+        response = requests.get(
+            media_url,
+            auth=(settings.account_sid, settings.auth_token),
+            timeout=30,
+        )
+        response.raise_for_status()
+        audio_bytes = response.content
+    except Exception:
+        logger.exception("transcribe_audio download_error url=%s", media_url)
+        return None
+
+    try:
+        client = OpenAI(api_key=settings.openai_api_key)
+        transcript = client.audio.transcriptions.create(
+            model="whisper-1",
+            file=("audio.ogg", io.BytesIO(audio_bytes), "audio/ogg"),
+            language="pt",
+        )
+        text = (transcript.text or "").strip()
+        logger.info("transcribe_audio ok chars=%d", len(text))
+        return text or None
+    except Exception:
+        logger.exception("transcribe_audio whisper_error")
+        return None

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -373,6 +373,16 @@ ONBOARDING_COMPLETE
   - [ ] "NÃO" descarta e solicita correção.
   - [ ] Nova transação pendente sobrescreve a anterior.
 
+#### [S5] Suporte a voz — Issue #28
+- O Navi aceita mensagens de voz enviadas pelo WhatsApp (formato `audio/ogg; codecs=opus`).
+- O áudio é transcrito via OpenAI Whisper (`whisper-1`) em português antes de ser processado como texto normal.
+- Se a transcrição falhar, o usuário recebe mensagem orientando a enviar por texto.
+- Não há saída de voz — respostas são sempre em texto.
+- **Critérios de aceite:**
+  - [ ] Mensagem de voz transcrita e processada como texto.
+  - [ ] Outros tipos de áudio (mp3, wav, webm, amr) também aceitos.
+  - [ ] Falha na transcrição não quebra o fluxo — retorna mensagem de fallback.
+
 #### [S5] Leitura de recibos e imagens — Issue #29
 - O Navi aceita imagens de recibos, extratos e faturas enviadas diretamente no WhatsApp.
 - Processamento via GPT-4.1-mini com visão multimodal.


### PR DESCRIPTION
## Resumo
- Novo `app/services/voice.py`: baixa áudio do Twilio, transcreve com Whisper `whisper-1` em pt-BR
- Webhook detecta `audio/*` antes do processamento de documentos; substitui `mensagem` pelo transcript e limpa `incoming_media` para que o fluxo normal processe como texto
- Fallback: se a transcrição falhar, retorna mensagem pedindo para enviar por texto
- Tipos suportados: `audio/ogg`, `audio/mpeg`, `audio/wav`, `audio/webm`, `audio/amr`
- SPEC.md atualizado com critérios de aceite da issue #28

Fixes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)