### PR TITLE
feat: WhatsApp UX — message splitting, greeting intent, empty fallback (#31)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -669,6 +669,12 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
             resposta = build_loan_evaluation_message(user_id, mensagem)
         elif intent == "financial_recommendations":
             resposta = build_recommendations_message(user_id)
+        elif intent == "greeting":
+            resposta = (
+                "Olá! Por aqui estou de olho nos seus gastos. "
+                "Pode registrar uma despesa, me perguntar quanto gastou, "
+                "ver sua saúde financeira ou enviar um extrato ou fatura."
+            )
         elif intent == "card_setup_request":
             set_onboarding_state(user_id, CARD_COUNT_PENDING)
             resposta = (
@@ -689,8 +695,17 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
             resposta = resumo_categoria(user_id, "alimentacao")
         elif "quanto gastei" in msg_lower:
             resposta = resumo_mes(user_id)
+        elif not mensagem:
+            resposta = "Recebi sua mensagem, mas estava vazia. Me manda o que você quiser registrar ou perguntar."
         else:
-            resposta = process_user_message(mensagem, user_id)["resposta"]
+            try:
+                resposta = process_user_message(mensagem, user_id)["resposta"]
+            except HTTPException as exc:
+                # 422 = mensagem não reconhecida como transação — responde com contexto útil
+                if exc.status_code == 422:
+                    resposta = exc.detail
+                else:
+                    raise
     except HTTPException as exc:
         resposta = exc.detail
     except Exception:

--- a/app/services/conversation.py
+++ b/app/services/conversation.py
@@ -11,6 +11,13 @@ from app.schemas import PendingTransaction
 CONFIRMATION_YES = {"sim", "s", "confirmar", "confirmo", "ok", "pode confirmar"}
 CONFIRMATION_NO = {"nao", "n", "cancelar", "corrigir"}
 
+GREETING_PATTERNS = {
+    "oi", "ola", "olá", "oi navi", "ola navi", "olá navi",
+    "bom dia", "boa tarde", "boa noite",
+    "tudo bem", "tudo bom", "como vai", "e ai", "e aí",
+    "hi", "hello", "hey",
+}
+
 QUERY_RECENT_PATTERNS = (
     "ultimos gastos",
     "ultimas transacoes",
@@ -136,6 +143,8 @@ def detect_intent(text: str) -> str:
         return "confirm_yes"
     if normalized in CONFIRMATION_NO:
         return "confirm_no"
+    if normalized in GREETING_PATTERNS:
+        return "greeting"
     if any(pattern in normalized for pattern in QUERY_RECENT_PATTERNS):
         return "recent_transactions"
     if any(pattern in normalized for pattern in QUERY_BUDGET_PATTERNS):

--- a/app/services/twilio.py
+++ b/app/services/twilio.py
@@ -2,6 +2,8 @@ import requests
 
 from app.config import get_settings
 
+_WHATSAPP_MAX_CHARS = 1500
+
 
 def responder(numero: str, mensagem: str) -> None:
     settings = get_settings()
@@ -22,6 +24,43 @@ def responder(numero: str, mensagem: str) -> None:
     requests.post(url, data=data, auth=(settings.account_sid, settings.auth_token), timeout=15)
 
 
+def _split_message(text: str, max_len: int = _WHATSAPP_MAX_CHARS) -> list[str]:
+    if len(text) <= max_len:
+        return [text]
+
+    parts: list[str] = []
+    current = ""
+
+    for para in text.split("\n\n"):
+        candidate = f"{current}\n\n{para}".strip() if current else para
+        if len(candidate) <= max_len:
+            current = candidate
+        else:
+            if current:
+                parts.append(current)
+            if len(para) <= max_len:
+                current = para
+            else:
+                # Split oversized paragraph at line boundaries
+                for line in para.split("\n"):
+                    candidate = f"{current}\n{line}".strip() if current else line
+                    if len(candidate) <= max_len:
+                        current = candidate
+                    else:
+                        if current:
+                            parts.append(current)
+                        current = line[:max_len]
+
+    if current:
+        parts.append(current)
+
+    return parts or [text[:max_len]]
+
+
 def build_twiml(message: str) -> str:
-    safe_message = message.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-    return f"<Response><Message>{safe_message}</Message></Response>"
+    chunks = _split_message(message)
+    msg_tags = "".join(
+        f"<Message>{c.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')}</Message>"
+        for c in chunks
+    )
+    return f"<Response>{msg_tags}</Response>"

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -425,6 +425,19 @@ ONBOARDING_COMPLETE
 
 ---
 
+#### [S5] Experiência mais fluida no WhatsApp — Issue #31
+- Mensagens longas (> 1.500 caracteres) são divididas automaticamente em múltiplos `<Message>` TwiML em parágrafos limpos.
+- Saudações ("oi", "bom dia", "como vai") são reconhecidas como intent `greeting` e recebem resposta natural sem tentar parsear como transação.
+- Mensagem vazia recebe resposta orientativa em vez de erro.
+- Respostas de erro de transação não reconhecida fornecem contexto útil em linguagem natural.
+- **Critérios de aceite:**
+  - [ ] Mensagem com > 1.500 chars é enviada como múltiplos `<Message>` sem cortar palavras.
+  - [ ] "Oi", "boa tarde", "tudo bem" retornam mensagem de boas-vindas, não erro de transação.
+  - [ ] Mensagem vazia retorna orientação natural.
+  - [ ] Todos os textos ao usuário usam português com diacríticos corretos.
+
+---
+
 ### S6 — Qualidade e produção
 
 #### [S6] Datas e valores 100% padronizados — Issue #33


### PR DESCRIPTION
## Resumo

- `build_twiml()` divide mensagens > 1.500 chars em múltiplos `<Message>` TwiML nos limites de parágrafo, evitando truncamentos no WhatsApp
- Novo intent `greeting` para saudações comuns ("oi", "bom dia", "tudo bem", etc.) — retorna mensagem orientativa natural em vez de tentar parsear como transação
- Mensagem vazia recebe resposta gentil orientativa em vez de erro
- `HTTPException 422` de `process_user_message` agora é surfaceado ao usuário com contexto útil
- SPEC.md atualizado com critérios de aceite da issue #31

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)