### PR TITLE
feat: add user registration step at onboarding start

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -191,6 +191,10 @@ SCHEMA_STATEMENTS = (
     """,
     "CREATE INDEX IF NOT EXISTS idx_transacoes_user_id ON transacoes(user_id)",
     "CREATE INDEX IF NOT EXISTS idx_transacoes_user_categoria ON transacoes(user_id, categoria)",
+    """
+    ALTER TABLE usuarios
+    ADD COLUMN IF NOT EXISTS nome VARCHAR(255) NULL
+    """,
 )
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -54,6 +54,7 @@ from app.services.financial_analysis import (
 from app.services.financial_health import build_financial_health_message
 from app.services.voice import is_audio_media, transcribe_audio
 from app.services.onboarding import (
+    USER_REGISTRATION_PENDING,
     ACCOUNT_SNAPSHOT_PENDING,
     BUDGET_SETUP_PENDING,
     CARD_COUNT_PENDING,
@@ -96,6 +97,11 @@ from app.services.onboarding import (
     save_current_balance,
     set_pending_card_index,
     set_onboarding_state,
+    get_user_name,
+    parse_user_name,
+    registration_prompt,
+    registration_retry_prompt,
+    save_user_name,
     should_skip_account_snapshot,
     should_skip_card_setup,
 )
@@ -178,7 +184,7 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
         resposta = (
             "Olá! Que bom ter você por aqui.\n\n"
             "Eu sou o Navi e vou te ajudar a acompanhar seus gastos de um jeito leve, sem complicação.\n\n"
-            f"{account_snapshot_prompt()}"
+            f"{registration_prompt()}"
         )
         return Response(content=build_twiml(resposta), media_type="application/xml")
 
@@ -212,6 +218,19 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
     logger.info("webhook user_id=%s intent=%s media=%s", user_id, intent, bool(incoming_media))
     onboarding_state = get_onboarding_state(user_id)
     existing_card_names = get_card_names(user_id)
+
+    if onboarding_state == USER_REGISTRATION_PENDING:
+        nome = parse_user_name(mensagem)
+        if nome:
+            save_user_name(user_id, nome)
+            set_onboarding_state(user_id, ACCOUNT_SNAPSHOT_PENDING)
+            resposta = (
+                f"Prazer, {nome}! Vou usar esse nome para te chamar por aqui.\n\n"
+                f"{account_snapshot_prompt()}"
+            )
+        else:
+            resposta = registration_retry_prompt()
+        return Response(content=build_twiml(resposta), media_type="application/xml")
 
     if onboarding_state == ACCOUNT_SNAPSHOT_PENDING:
         if incoming_media:
@@ -670,8 +689,10 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
         elif intent == "financial_recommendations":
             resposta = build_recommendations_message(user_id)
         elif intent == "greeting":
+            _nome = get_user_name(user_id)
+            _saudacao = f"Olá, {_nome}!" if _nome else "Olá!"
             resposta = (
-                "Olá! Por aqui estou de olho nos seus gastos. "
+                f"{_saudacao} Por aqui estou de olho nos seus gastos. "
                 "Pode registrar uma despesa, me perguntar quanto gastou, "
                 "ver sua saúde financeira ou enviar um extrato ou fatura."
             )

--- a/app/services/onboarding.py
+++ b/app/services/onboarding.py
@@ -9,6 +9,7 @@ from app.config import get_settings
 from app.db import get_cursor
 from app.services.formatting import format_brl
 
+USER_REGISTRATION_PENDING = "user_registration_pending"
 ACCOUNT_SNAPSHOT_PENDING = "account_snapshot_pending"
 BUDGET_SETUP_PENDING = "budget_setup_pending"
 COST_REVIEW_PENDING = "cost_review_pending"
@@ -130,10 +131,88 @@ def _normalize_text(text: str) -> str:
     return normalized.encode("ascii", "ignore").decode("ascii")
 
 
+# ---------------------------------------------------------------------------
+# User registration (issue #46)
+# ---------------------------------------------------------------------------
+
+_NAME_MIN_LEN = 2
+_NAME_MAX_LEN = 60
+_NON_NAME_TOKENS = {
+    "sim", "nao", "não", "ok", "pular", "depois", "oi", "ola", "olá",
+    "bom", "dia", "tarde", "noite", "tudo", "bem", "claro", "pode",
+    "s", "n", "nao sei", "não sei",
+}
+
+
+def registration_prompt() -> str:
+    return (
+        "Antes de começar, qual é o seu nome?\n\n"
+        "Pode ser seu primeiro nome ou como você prefere ser chamado. "
+        "Uso essa informação apenas para te chamar pelo nome aqui dentro — "
+        "nenhum dado sensível é solicitado e seus dados são protegidos conforme a LGPD."
+    )
+
+
+def registration_retry_prompt() -> str:
+    return (
+        "Não consegui identificar um nome válido. "
+        "Pode me dizer como você gosta de ser chamado? "
+        "Pode ser seu primeiro nome, como João ou Maria."
+    )
+
+
+def parse_user_name(text: str) -> str | None:
+    stripped = text.strip()
+    if not stripped or len(stripped) > _NAME_MAX_LEN:
+        return None
+
+    normalized = _normalize_text(stripped)
+
+    # Reject obvious non-names
+    if normalized in _NON_NAME_TOKENS:
+        return None
+
+    # Remove common lead-in phrases: "me chamo X", "meu nome é X", "pode me chamar de X"
+    for pattern in (
+        r"^(?:me\s+chamo|meu\s+nome\s+(?:é|e)|pode\s+me\s+chamar\s+de|sou\s+o|sou\s+a)\s+",
+    ):
+        stripped = re.sub(pattern, "", stripped, flags=re.IGNORECASE).strip()
+
+    # Must contain at least one letter
+    if not re.search(r"[A-Za-zÀ-ÿ]", stripped):
+        return None
+
+    # Must be >= min length after trimming
+    if len(stripped) < _NAME_MIN_LEN:
+        return None
+
+    # Capitalize each word nicely
+    return stripped.title()
+
+
+def save_user_name(user_id: int, nome: str) -> None:
+    with get_cursor() as (conn, cursor):
+        cursor.execute(
+            "UPDATE usuarios SET nome = %s WHERE id = %s",
+            (nome, user_id),
+        )
+        conn.commit()
+
+
+def get_user_name(user_id: int) -> str | None:
+    with get_cursor() as (_, cursor):
+        cursor.execute("SELECT nome FROM usuarios WHERE id = %s", (user_id,))
+        row = cursor.fetchone()
+    return str(row[0]) if row and row[0] else None
+
+
+# ---------------------------------------------------------------------------
+
+
 def account_snapshot_prompt() -> str:
     return (
-        "Para eu te orientar melhor desde o comeco, queria entender como esta sua vida financeira hoje.\n\n"
-        "Voce pode me dizer seu saldo atual ou me enviar o extrato de hoje.\n\n"
+        "Para eu te orientar melhor desde o começo, queria entender como está sua vida financeira hoje.\n\n"
+        "Você pode me dizer seu saldo atual ou me enviar o extrato de hoje.\n\n"
         'Se preferir, pode responder "PULAR" e seguimos mesmo assim.'
     )
 

--- a/app/services/users.py
+++ b/app/services/users.py
@@ -4,6 +4,7 @@ from psycopg2 import IntegrityError
 from app.auth import hash_password, verify_password
 from app.db import get_cursor
 from app.services.budgets import ensure_user_settings
+from app.services.onboarding import USER_REGISTRATION_PENDING, set_onboarding_state
 
 AUTO_PASSWORD_PREFIX = "whatsapp-user:"
 
@@ -56,6 +57,7 @@ def get_or_create_whatsapp_user(numero: str) -> tuple[int, bool]:
         conn.commit()
         user_id = int(created[0])
         ensure_user_settings(user_id)
+        set_onboarding_state(user_id, USER_REGISTRATION_PENDING)
         return user_id, True
 
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -466,6 +466,17 @@ ONBOARDING_COMPLETE
 - Parsing de nomes de cartão não aceita saudações ou confirmações como nomes válidos.
 - Parsing de quantidade de cartões aceita palavras por extenso além de dígitos.
 
+#### [S6] Etapa de registro do usuário — Issue #46
+- Novo usuário WhatsApp inicia em `user_registration_pending` antes de `account_snapshot_pending`.
+- Navi solicita apenas o nome preferido (primeiro nome ou apelido) — sem dados sensíveis.
+- Prompt inclui aviso de privacidade LGPD: uso restrito a personalização, dados protegidos.
+- Nome válido: 2–60 caracteres, sem tokens inválidos (e.g., "sim", "não", números puros).
+- Resposta inválida → retry com mensagem curta sem repetir o aviso completo.
+- Após nome aceito: saudação personalizada + transição automática para `account_snapshot_pending`.
+- Coluna `nome VARCHAR(255) NULL` adicionada à tabela `usuarios` via migração idempotente.
+- Saudação (`greeting`) personalizada: "Olá, {nome}!" quando nome cadastrado.
+- Usuários registrados via API REST não passam por essa etapa (iniciam direto em `account_snapshot_pending`).
+
 ---
 
 ## Detalhamento de Integrações


### PR DESCRIPTION
## Summary
- New WhatsApp users begin in `user_registration_pending` state and are asked for their preferred name before the financial snapshot step
- Name stored in `usuarios.nome` via idempotent DB migration; LGPD privacy notice embedded in prompt
- Greeting responses personalised with stored name; invalid inputs handled with a short retry prompt

## Changes
- `app/db.py`: idempotent `ALTER TABLE usuarios ADD COLUMN IF NOT EXISTS nome VARCHAR(255) NULL`
- `app/services/onboarding.py`: `USER_REGISTRATION_PENDING` constant, `registration_prompt()`, `registration_retry_prompt()`, `parse_user_name()`, `save_user_name()`, `get_user_name()`
- `app/services/users.py`: set initial state to `user_registration_pending` for new WhatsApp users
- `app/main.py`: `USER_REGISTRATION_PENDING` handler as first state block; greeting personalised with name
- `docs/SPEC.md`: acceptance criteria for issue #46

## Test plan
- [ ] New WhatsApp number → receives registration prompt asking for name
- [ ] Send invalid input (e.g. "sim", single char, number) → receives retry message
- [ ] Send valid name → receives "Prazer, {nome}!" + account snapshot prompt
- [ ] Send greeting afterwards → receives "Olá, {nome}!" personalised response
- [ ] Existing users unaffected; API-registered users skip registration step

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)