### PR TITLE
fix: replace Gemini with OpenAI vision fallback for scanned PDFs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,7 +38,6 @@ jobs:
       AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
       TWILIO_NUMBER: ${{ secrets.TWILIO_NUMBER }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       SECRET_KEY: ${{ secrets.SECRET_KEY }}
       ALGORITHM: HS256
       DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
@@ -67,7 +66,7 @@ jobs:
           host: ${{ secrets.VM_HOST }}
           username: ${{ secrets.VM_SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          envs: ACR_REGISTRY,ACCOUNT_SID,AUTH_TOKEN,TWILIO_NUMBER,OPENAI_API_KEY,GEMINI_API_KEY,SECRET_KEY,ALGORITHM,DATABASE_PASSWORD
+          envs: ACR_REGISTRY,ACCOUNT_SID,AUTH_TOKEN,TWILIO_NUMBER,OPENAI_API_KEY,SECRET_KEY,ALGORITHM,DATABASE_PASSWORD
           script: |
             set -e
 
@@ -81,7 +80,6 @@ jobs:
               "AUTH_TOKEN=${AUTH_TOKEN}" \
               "TWILIO_NUMBER=${TWILIO_NUMBER}" \
               "OPENAI_API_KEY=${OPENAI_API_KEY}" \
-              "GEMINI_API_KEY=${GEMINI_API_KEY}" \
               "SECRET_KEY=${SECRET_KEY}" \
               "ALGORITHM=${ALGORITHM}" \
               "DATABASE_PASSWORD=${DATABASE_PASSWORD}" > .env

--- a/app/config.py
+++ b/app/config.py
@@ -23,7 +23,6 @@ class Settings(BaseSettings):
     algorithm: str = Field(default="HS256", alias="ALGORITHM")
 
     openai_api_key: str = Field(default="", alias="OPENAI_API_KEY")
-    gemini_api_key: str = Field(default="", alias="GEMINI_API_KEY")
 
     database_host: str = Field(default="db", alias="DATABASE_HOST")
     database_name: str = Field(default="navimvp", alias="DATABASE_NAME")

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -10,4 +10,4 @@ python-jose==3.5.0
 pydantic-settings==2.10.1
 python-multipart==0.0.20
 email-validator==2.2.0
-google-generativeai==0.8.3
+pymupdf==1.24.14

--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -1,9 +1,7 @@
 import base64
 from difflib import SequenceMatcher
 import json
-import os
 import re
-import tempfile
 import unicodedata
 from datetime import datetime
 from io import BytesIO
@@ -416,57 +414,74 @@ def _build_document_analysis_system_prompt(income_instructions: str, hinted_type
     return base
 
 
-def _extract_document_analysis_with_gemini(
+def _render_pdf_pages_as_images(media_bytes: bytes, max_pages: int = 10) -> list[bytes]:
+    """Renders PDF pages as PNG images using pymupdf (for scanned/image-based PDFs)."""
+    try:
+        import fitz  # noqa: PLC0415 — pymupdf
+
+        doc = fitz.open(stream=media_bytes, filetype="pdf")
+        images: list[bytes] = []
+        for page_num in range(min(len(doc), max_pages)):
+            page = doc.load_page(page_num)
+            pix = page.get_pixmap(dpi=150)
+            images.append(pix.tobytes("png"))
+        return images
+    except Exception:
+        return []
+
+
+def _extract_scanned_pdf_with_openai(
     message_text: str,
-    media_content_type: str,
     media_bytes: bytes,
     hinted_type: str,
+    system_content: str,
 ) -> dict[str, Any] | None:
+    """Sends rendered PDF pages as images to GPT-4.1-mini vision when pypdf extracts no text."""
     settings = get_settings()
-    if not settings.gemini_api_key:
+    if not settings.openai_api_key:
         return None
 
-    try:
-        import google.generativeai as genai  # noqa: PLC0415
+    page_images = _render_pdf_pages_as_images(media_bytes)
+    if not page_images:
+        return None
 
-        genai.configure(api_key=settings.gemini_api_key)
-        model = genai.GenerativeModel("gemini-1.5-flash")
+    client = OpenAI(api_key=settings.openai_api_key)
 
-        income_instructions = _income_detection_instructions(hinted_type)
-        system_content = _build_document_analysis_system_prompt(income_instructions, hinted_type)
-        user_text = (
-            f"Mensagem do usuario: {message_text or 'sem legenda'}.\n"
-            f"Tipo sugerido inicialmente: {hinted_type}.\n"
-            "Extraia todas as linhas visiveis do documento com alta precisao. "
-            "Quando for extrato, preencha statement_rows linha a linha sem omitir entradas."
+    image_content: list[dict[str, Any]] = [
+        {
+            "type": "text",
+            "text": (
+                f"Mensagem do usuario: {message_text or 'sem legenda'}.\n"
+                f"Tipo sugerido inicialmente: {hinted_type}.\n"
+                "As imagens abaixo sao paginas de um PDF escaneado. "
+                "Extraia todas as linhas visiveis com alta precisao e preencha statement_rows linha a linha sem omitir entradas."
+            ),
+        }
+    ]
+    for img_bytes in page_images:
+        encoded = base64.b64encode(img_bytes).decode("utf-8")
+        image_content.append(
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/png;base64,{encoded}"},
+            }
         )
-        full_prompt = f"{system_content}\n\n{user_text}"
 
-        if media_content_type == "application/pdf":
-            tmp_fd, tmp_path = tempfile.mkstemp(suffix=".pdf")
-            try:
-                with os.fdopen(tmp_fd, "wb") as tmp_file:
-                    tmp_file.write(media_bytes)
-                uploaded = genai.upload_file(tmp_path, mime_type="application/pdf")
-                response = model.generate_content([full_prompt, uploaded])
-                genai.delete_file(uploaded.name)
-            finally:
-                os.unlink(tmp_path)
-        else:
-            encoded = base64.b64encode(media_bytes).decode("utf-8")
-            image_part = {"mime_type": media_content_type, "data": encoded}
-            response = model.generate_content([full_prompt, image_part])
-
-        content = response.text or "{}"
-        analysis = _parse_openai_json(content)
-        analysis["document_type"] = analysis.get("document_type") or hinted_type
-        analysis["statement_rows"] = _normalize_statement_rows(analysis.get("statement_rows"))
-        derived_credit, derived_debit = _derive_statement_entries(analysis["statement_rows"])
-        analysis["credit_entries"] = derived_credit or _normalize_statement_entries(analysis.get("credit_entries"))
-        analysis["debit_entries"] = derived_debit or _normalize_statement_entries(analysis.get("debit_entries"))
-        return _normalize_income_signal(analysis, hinted_type)
-    except Exception:
-        return None
+    response = client.chat.completions.create(
+        model="gpt-4.1-mini",
+        messages=[
+            {"role": "system", "content": system_content},
+            {"role": "user", "content": image_content},
+        ],
+    )
+    content = response.choices[0].message.content or "{}"
+    analysis = _parse_openai_json(content)
+    analysis["document_type"] = analysis.get("document_type") or hinted_type
+    analysis["statement_rows"] = _normalize_statement_rows(analysis.get("statement_rows"))
+    derived_credit, derived_debit = _derive_statement_entries(analysis["statement_rows"])
+    analysis["credit_entries"] = derived_credit or _normalize_statement_entries(analysis.get("credit_entries"))
+    analysis["debit_entries"] = derived_debit or _normalize_statement_entries(analysis.get("debit_entries"))
+    return _normalize_income_signal(analysis, hinted_type)
 
 
 def has_document_type(user_id: int, tipo_documento: str) -> bool:
@@ -906,15 +921,13 @@ def _extract_document_analysis(
     income_instructions = _income_detection_instructions(hinted_type)
     system_content = _build_document_analysis_system_prompt(income_instructions, hinted_type)
 
+    if not settings.openai_api_key:
+        return None
+
     if media_content_type == "application/pdf":
         extracted_text = _extract_pdf_text(media_bytes)
-        if not extracted_text and settings.gemini_api_key:
-            return _extract_document_analysis_with_gemini(message_text, media_content_type, media_bytes, hinted_type)
         if not extracted_text:
-            return None
-
-        if not settings.openai_api_key:
-            return None
+            return _extract_scanned_pdf_with_openai(message_text, media_bytes, hinted_type, system_content)
 
         client = OpenAI(api_key=settings.openai_api_key)
         response = client.chat.completions.create(
@@ -933,9 +946,6 @@ def _extract_document_analysis(
             ],
         )
     else:
-        if not settings.openai_api_key:
-            return _extract_document_analysis_with_gemini(message_text, media_content_type, media_bytes, hinted_type)
-
         client = OpenAI(api_key=settings.openai_api_key)
         encoded_media = base64.b64encode(media_bytes).decode("utf-8")
         data_url = f"data:{media_content_type};base64,{encoded_media}"


### PR DESCRIPTION
## Resumo

Remove a integração com Gemini e substitui pelo fallback via OpenAI vision usando `pymupdf` para renderizar páginas de PDFs escaneados.

## Mudanças

- `app/requirements.txt`: substitui `google-generativeai` por `pymupdf==1.24.14`
- `app/config.py`: remove campo `gemini_api_key`
- `app/services/documents.py`:
  - `_render_pdf_pages_as_images()`: renderiza cada página do PDF como PNG via pymupdf
  - `_extract_scanned_pdf_with_openai()`: envia as páginas renderizadas ao GPT-4.1-mini vision quando pypdf retorna texto vazio (PDFs escaneados)
  - `_extract_document_analysis()`: fallback limpo usando apenas OpenAI
- `.github/workflows/ci-cd.yml`: remove `GEMINI_API_KEY` do workflow e do script de deploy

## Variável de ambiente

O secret `OPENAI_API_KEY` já existe no repositório e cobre todos os casos de uso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)