### PR TITLE
fix: add cost review step after invoice upload in onboarding

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -80,6 +80,7 @@ from app.services.onboarding import (
     cost_review_prompt,
     cost_review_retry_prompt,
     has_cost_review_candidates,
+    infer_invoice_cost_candidates,
     get_current_card,
     get_card_names,
     get_onboarding_state,
@@ -386,14 +387,30 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
         return Response(content=build_twiml(resposta), media_type="application/xml")
 
     if onboarding_state == COST_REVIEW_PENDING:
-        fixed_costs, variable_costs = infer_cost_candidates(user_id)
+        is_post_cards = bool(existing_card_names)
+        if is_post_cards:
+            fixed_costs, variable_costs = infer_invoice_cost_candidates(user_id)
+        else:
+            fixed_costs, variable_costs = infer_cost_candidates(user_id)
+
         if not fixed_costs and not variable_costs:
+            if is_post_cards:
+                complete_document_onboarding(user_id)
+                summary_msg, ready_msg = build_onboarding_completion_message(user_id)
+                return Response(content=build_twiml([summary_msg, ready_msg]), media_type="application/xml")
             set_onboarding_state(user_id, CARD_COUNT_PENDING)
             resposta = card_count_prompt()
             return Response(content=build_twiml(resposta), media_type="application/xml")
 
+        origem = "fatura" if is_post_cards else "extrato"
+
         if should_skip_budget_onboarding(mensagem):
-            save_cost_candidates(user_id, confirmed=False)
+            save_cost_candidates(user_id, confirmed=False, fixed_costs=fixed_costs, variable_costs=variable_costs, origem=origem)
+            if is_post_cards:
+                complete_document_onboarding(user_id)
+                skip_msg = "Tudo bem. A gente pode revisar esses custos com calma mais para frente."
+                summary_msg, ready_msg = build_onboarding_completion_message(user_id)
+                return Response(content=build_twiml([skip_msg, summary_msg, ready_msg]), media_type="application/xml")
             set_onboarding_state(user_id, CARD_COUNT_PENDING)
             resposta = (
                 "Tudo bem. A gente pode revisar esses custos com calma mais para frente.\n\n"
@@ -409,7 +426,13 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
                 confirmed=True,
                 fixed_costs=adjusted_fixed,
                 variable_costs=adjusted_variable,
+                origem=origem,
             )
+            if is_post_cards:
+                complete_document_onboarding(user_id)
+                summary_msg, ready_msg = build_onboarding_completion_message(user_id)
+                confirmation_msg = build_cost_review_confirmation(adjusted_fixed, adjusted_variable)
+                return Response(content=build_twiml([confirmation_msg, summary_msg, ready_msg]), media_type="application/xml")
             set_onboarding_state(user_id, CARD_COUNT_PENDING)
             resposta = (
                 f"{build_cost_review_confirmation(adjusted_fixed, adjusted_variable)}\n\n"
@@ -418,7 +441,12 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
             return Response(content=build_twiml(resposta), media_type="application/xml")
 
         if is_confirmation_yes(mensagem):
-            save_cost_candidates(user_id, confirmed=True)
+            save_cost_candidates(user_id, confirmed=True, fixed_costs=fixed_costs, variable_costs=variable_costs, origem=origem)
+            if is_post_cards:
+                complete_document_onboarding(user_id)
+                summary_msg, ready_msg = build_onboarding_completion_message(user_id)
+                confirm_msg = "Perfeito. Vou considerar essa leitura dos seus custos para te acompanhar melhor."
+                return Response(content=build_twiml([confirm_msg, summary_msg, ready_msg]), media_type="application/xml")
             set_onboarding_state(user_id, CARD_COUNT_PENDING)
             resposta = (
                 "Perfeito. Vou considerar essa leitura inicial dos seus custos para te acompanhar melhor.\n\n"
@@ -556,10 +584,20 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
                         f"Agora me manda a fatura atual do {next_card['nome_cartao']}."
                     )
                 else:
-                    complete_document_onboarding(user_id)
-                    summary_msg, ready_msg = build_onboarding_completion_message(user_id)
-                    intro = f"Perfeito. Já deixei a fatura do {current_card['nome_cartao']} salva por aqui.\n\n{summary_msg}"
-                    return Response(content=build_twiml([intro, ready_msg]), media_type="application/xml")
+                    set_onboarding_state(user_id, COST_REVIEW_PENDING)
+                    invoice_fixed, invoice_variable = infer_invoice_cost_candidates(user_id)
+                    card_name_display = str(current_card["nome_cartao"])
+                    if invoice_fixed or invoice_variable:
+                        resposta = (
+                            f"Perfeito. Já deixei a fatura do {card_name_display} salva por aqui.\n\n"
+                            f"{cost_review_prompt(invoice_fixed, invoice_variable)}"
+                        )
+                    else:
+                        resposta = (
+                            f"Perfeito. Já deixei a fatura do {card_name_display} salva por aqui.\n\n"
+                            "Estou analisando os lançamentos em segundo plano. "
+                            "Me responda qualquer coisa para eu te mostrar o que identifiquei."
+                        )
                 return Response(content=build_twiml(resposta), media_type="application/xml")
 
             if should_skip_document_onboarding(mensagem):

--- a/app/services/onboarding.py
+++ b/app/services/onboarding.py
@@ -871,28 +871,29 @@ def save_cost_candidates(
     confirmed: bool,
     fixed_costs: list[dict[str, float | str]] | None = None,
     variable_costs: list[dict[str, float | str]] | None = None,
+    origem: str = "extrato",
 ) -> None:
     if fixed_costs is None or variable_costs is None:
         fixed_costs, variable_costs = infer_cost_candidates(user_id)
     with get_cursor() as (conn, cursor):
         if _table_exists(cursor, "custos_mensais"):
-            cursor.execute("DELETE FROM custos_mensais WHERE user_id = %s AND origem = 'extrato'", (user_id,))
+            cursor.execute("DELETE FROM custos_mensais WHERE user_id = %s AND origem = %s", (user_id, origem))
             if confirmed:
                 for item in fixed_costs:
                     cursor.execute(
                         """
                         INSERT INTO custos_mensais (user_id, descricao, categoria, valor_medio, tipo_custo, confirmado, origem)
-                        VALUES (%s, %s, %s, %s, 'fixo', TRUE, 'extrato')
+                        VALUES (%s, %s, %s, %s, 'fixo', TRUE, %s)
                         """,
-                        (user_id, item["descricao"], item.get("categoria"), item["valor"]),
+                        (user_id, item["descricao"], item.get("categoria"), item["valor"], origem),
                     )
                 for item in variable_costs:
                     cursor.execute(
                         """
                         INSERT INTO custos_mensais (user_id, descricao, categoria, valor_medio, tipo_custo, confirmado, origem)
-                        VALUES (%s, %s, %s, %s, 'variavel', TRUE, 'extrato')
+                        VALUES (%s, %s, %s, %s, 'variavel', TRUE, %s)
                         """,
-                        (user_id, item["descricao"], item.get("categoria"), item["valor"]),
+                        (user_id, item["descricao"], item.get("categoria"), item["valor"], origem),
                     )
 
         if _column_exists(cursor, "configuracoes_usuario", "custos_onboarding_concluido"):
@@ -1351,3 +1352,73 @@ def save_current_balance(user_id: int, balance: float) -> None:
             (user_id, balance),
         )
         conn.commit()
+
+
+def _latest_invoice_analysis(user_id: int) -> dict | None:
+    with get_cursor() as (_, cursor):
+        if not _table_exists(cursor, "documentos_financeiros"):
+            return None
+        cursor.execute(
+            """
+            SELECT extracted_json
+            FROM documentos_financeiros
+            WHERE user_id = %s
+              AND tipo_documento = 'fatura_cartao'
+              AND extracted_json IS NOT NULL
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            (user_id,),
+        )
+        row = cursor.fetchone()
+    if not row or not row[0]:
+        return None
+    try:
+        parsed = json.loads(row[0])
+    except (TypeError, json.JSONDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def infer_invoice_cost_candidates(user_id: int) -> tuple[list[dict[str, float | str]], list[dict[str, float | str]]]:
+    analysis = _latest_invoice_analysis(user_id)
+    if not analysis:
+        return [], []
+
+    debit_entries = analysis.get("debit_entries")
+    if not isinstance(debit_entries, list):
+        return [], []
+
+    fixed_costs: list[dict[str, float | str]] = []
+    variable_costs: list[dict[str, float | str]] = []
+    seen_keys: set[str] = set()
+
+    for entry in debit_entries:
+        if not isinstance(entry, dict):
+            continue
+        description = str(entry.get("description") or "").strip()
+        amount = _normalize_amount(entry.get("amount"))
+        if not description or amount is None:
+            continue
+
+        cost_type = _classify_cost_type(description)
+        if not cost_type:
+            continue
+
+        key = _normalize_text(description)
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+
+        payload: dict[str, float | str] = {
+            "descricao": description,
+            "valor": amount,
+            "tipo_custo": cost_type,
+            "categoria": _classify_cost_category(description) or "outros",
+        }
+        if cost_type == "fixo":
+            fixed_costs.append(payload)
+        else:
+            variable_costs.append(payload)
+
+    return fixed_costs[:4], variable_costs[:4]


### PR DESCRIPTION
## Summary

- Após o envio da última fatura de cartão em `CARD_INVOICE_PENDING`, o estado agora avança para `COST_REVIEW_PENDING` em vez de `ONBOARDING_COMPLETE` diretamente
- Nova função `infer_invoice_cost_candidates()` em `onboarding.py` extrai lançamentos da fatura processada e os classifica como fixo/variável usando a mesma lógica do extrato
- O handler `COST_REVIEW_PENDING` detecta o cenário pós-cartões (`is_post_cards`) e usa os candidatos da fatura; após confirmação/ajuste/pular, chama `complete_document_onboarding` → `ONBOARDING_COMPLETE`
- `save_cost_candidates` agora aceita `origem` (default `"extrato"`, passa `"fatura"` no contexto pós-cartões) para isolar corretamente os registros em `custos_mensais`

Fixes #63

## Test plan

- [ ] Usuário envia fatura do último cartão → Navi exibe lista de custos fixos/variáveis identificados
- [ ] Usuário confirma com "SIM" → custos salvos com `origem='fatura'`, onboarding completo
- [ ] Usuário responde "PULAR" → avança para onboarding completo sem salvar
- [ ] Usuário ajusta classificação → custos ajustados salvos, onboarding completo
- [ ] Fatura ainda não processada (background task) → COST_REVIEW_PENDING com candidatos vazios → avança automaticamente para ONBOARDING_COMPLETE
- [ ] Extrato cost review (antes dos cartões) continua funcionando normalmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)