### PR TITLE
fix: correctly detect invoice status intent after onboarding

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -723,11 +723,17 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
         elif intent == "confirm_no":
             resposta = reject_pending_transaction(user_id)
         elif intent == "document_request":
-            start_document_onboarding(user_id)
-            resposta = (
-                "Claro. Posso te ajudar com esse documento.\n\n"
-                f"{document_upload_prompt(user_id)}"
-            )
+            if onboarding_state == ONBOARDING_COMPLETE:
+                resposta = (
+                    "Claro. Pode me mandar agora um extrato ou fatura pelo WhatsApp.\n\n"
+                    "Pode ser imagem ou PDF — assim que receber, já começo a analisar."
+                )
+            else:
+                start_document_onboarding(user_id)
+                resposta = (
+                    "Claro. Posso te ajudar com esse documento.\n\n"
+                    f"{document_upload_prompt(user_id)}"
+                )
         elif intent == "invoice_status":
             resposta = build_invoice_status_message(user_id, mensagem)
         elif intent == "financial_health":

--- a/app/services/conversation.py
+++ b/app/services/conversation.py
@@ -36,13 +36,27 @@ QUERY_BUDGET_PATTERNS = (
 QUERY_INVOICE_PATTERNS = (
     "qual o valor da minha fatura",
     "qual o valor da fatura",
+    "valor atual da fatura",
+    "valor da fatura",
     "quanto esta a fatura",
     "quanto está a fatura",
-    "valor da fatura",
+    "quanto é a fatura",
+    "quanto e a fatura",
+    "qual e a fatura",
+    "qual é a fatura",
     "minha fatura do",
+    "minha fatura esta",
+    "minha fatura está",
+    "fatura do meu",
+    "fatura atual do",
     "fatura do santander",
     "fatura do bradesco",
     "fatura do nubank",
+    "fatura do itau",
+    "fatura do inter",
+    "consultar fatura",
+    "ver fatura",
+    "checar fatura",
 )
 
 QUERY_FINANCIAL_HEALTH_PATTERNS = (


### PR DESCRIPTION
## Summary

- Adicionados 14 novos padrões a `QUERY_INVOICE_PATTERNS` em `conversation.py` cobrindo variações como `"valor atual da fatura"`, `"fatura do meu"`, `"fatura atual do"`, `"consultar fatura"` etc — o intent `invoice_status` é checado antes de `document_request`, então essas queries agora são roteadas corretamente
- Corrigido o handler `document_request` em `main.py` para não chamar `start_document_onboarding` (que reseta o estado para `CARD_INVOICE_PENDING`) quando o usuário já está em `ONBOARDING_COMPLETE` — agora responde simplesmente pedindo o envio do documento sem alterar o estado

**Raiz do problema:** "qual o valor atual da fatura do meu cartão de crédito?" normalizava para `"qual o valor atual da fatura do meu cartao de credito?"`. O padrão `"valor da fatura"` não batia porque `"atual"` está entre `"valor"` e `"da fatura"`. Com o novo padrão `"valor atual da fatura"` (e `"fatura do meu"`), o intent é detectado corretamente.

Fixes #64

## Test plan

- [ ] "qual o valor atual da fatura do meu cartão de crédito?" → intent `invoice_status` → retorna valor da fatura cadastrada
- [ ] "qual e a fatura do nubank?" → intent `invoice_status`
- [ ] "fatura do meu cartão" → intent `invoice_status`
- [ ] "consultar fatura" → intent `invoice_status`
- [ ] "quero enviar minha fatura" → ainda cai em `document_request` (não tem padrão de valor/consulta)
- [ ] Em `ONBOARDING_COMPLETE`, intent `document_request` não chama `start_document_onboarding` nem reseta estado

🤖 Generated with [Claude Code](https://claude.com/claude-code)