### PR TITLE
fix: reorder categorias migration to prevent startup crash

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -216,6 +216,10 @@ SCHEMA_STATEMENTS = (
     ADD COLUMN IF NOT EXISTS data_debito_encargos DATE NULL
     """,
     """
+    UPDATE categorias SET nome = INITCAP(nome)
+    WHERE nome ~ '^[a-z]'
+    """,
+    """
     INSERT INTO categorias (nome, subcategorias) VALUES
         ('Alimentacao',  'supermercado, restaurante, delivery, padaria, lanche, hortifruti'),
         ('Transporte',   'combustivel, uber, taxi, estacionamento, onibus, metro, pedagio'),
@@ -228,10 +232,6 @@ SCHEMA_STATEMENTS = (
         ('Vestuario',    'roupas, calcados, acessorios'),
         ('Outros',       'gorjeta, doacao, presente, diversos')
     ON CONFLICT (nome) DO NOTHING
-    """,
-    """
-    UPDATE categorias SET nome = INITCAP(nome)
-    WHERE nome ~ '^[a-z]'
     """,
 )
 

--- a/app/db.py
+++ b/app/db.py
@@ -217,17 +217,21 @@ SCHEMA_STATEMENTS = (
     """,
     """
     INSERT INTO categorias (nome, subcategorias) VALUES
-        ('alimentacao',  'supermercado, restaurante, delivery, padaria, lanche, hortifruti'),
-        ('transporte',   'combustivel, uber, taxi, estacionamento, onibus, metro, pedagio'),
-        ('saude',        'farmacia, consulta, exame, plano_saude, dentista, academia'),
-        ('moradia',      'aluguel, condominio, energia, agua, gas, internet, manutencao'),
-        ('educacao',     'mensalidade, material, curso, livros, escola'),
-        ('lazer',        'cinema, streaming, viagem, hobby, esporte, assinatura'),
-        ('comunicacao',  'telefone, celular, tv_a_cabo, plano_dados'),
-        ('financeiro',   'parcela, emprestimo, financiamento, seguro, taxa_bancaria, cartao'),
-        ('vestuario',    'roupas, calcados, acessorios'),
-        ('outros',       'gorjeta, doacao, presente, diversos')
+        ('Alimentacao',  'supermercado, restaurante, delivery, padaria, lanche, hortifruti'),
+        ('Transporte',   'combustivel, uber, taxi, estacionamento, onibus, metro, pedagio'),
+        ('Saude',        'farmacia, consulta, exame, plano_saude, dentista, academia'),
+        ('Moradia',      'aluguel, condominio, energia, agua, gas, internet, manutencao'),
+        ('Educacao',     'mensalidade, material, curso, livros, escola'),
+        ('Lazer',        'cinema, streaming, viagem, hobby, esporte, assinatura'),
+        ('Comunicacao',  'telefone, celular, tv_a_cabo, plano_dados'),
+        ('Financeiro',   'parcela, emprestimo, financiamento, seguro, taxa_bancaria, cartao'),
+        ('Vestuario',    'roupas, calcados, acessorios'),
+        ('Outros',       'gorjeta, doacao, presente, diversos')
     ON CONFLICT (nome) DO NOTHING
+    """,
+    """
+    UPDATE categorias SET nome = INITCAP(nome)
+    WHERE nome ~ '^[a-z]'
     """,
 )
 

--- a/app/main.py
+++ b/app/main.py
@@ -723,11 +723,17 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
         elif intent == "confirm_no":
             resposta = reject_pending_transaction(user_id)
         elif intent == "document_request":
-            start_document_onboarding(user_id)
-            resposta = (
-                "Claro. Posso te ajudar com esse documento.\n\n"
-                f"{document_upload_prompt(user_id)}"
-            )
+            if onboarding_state == ONBOARDING_COMPLETE:
+                resposta = (
+                    "Claro. Pode me mandar agora um extrato ou fatura pelo WhatsApp.\n\n"
+                    "Pode ser imagem ou PDF — assim que receber, já começo a analisar."
+                )
+            else:
+                start_document_onboarding(user_id)
+                resposta = (
+                    "Claro. Posso te ajudar com esse documento.\n\n"
+                    f"{document_upload_prompt(user_id)}"
+                )
         elif intent == "invoice_status":
             resposta = build_invoice_status_message(user_id, mensagem)
         elif intent == "financial_health":

--- a/app/main.py
+++ b/app/main.py
@@ -781,9 +781,9 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
             else:
                 resposta = build_all_budgets_status_message(user_id)
         elif "quanto gastei" in msg_lower and "transporte" in msg_lower:
-            resposta = resumo_categoria(user_id, "transporte")
+            resposta = resumo_categoria(user_id, "Transporte")
         elif "quanto gastei" in msg_lower and "alimentacao" in msg_lower:
-            resposta = resumo_categoria(user_id, "alimentacao")
+            resposta = resumo_categoria(user_id, "Alimentacao")
         elif "quanto gastei" in msg_lower:
             resposta = resumo_mes(user_id)
         elif not mensagem:

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -4,6 +4,7 @@ psycopg2-binary==2.9.10
 openai==1.99.9
 requests==2.32.3
 pypdf==5.4.0
+pdfplumber==0.11.4
 passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
 python-jose==3.5.0

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -12,13 +12,13 @@ class Message(BaseModel):
 
 class ParsedTransaction(BaseModel):
     tipo: str = "despesa"
-    categoria: str = "outros"
+    categoria: str = "Outros"
     valor: float = 0
 
 
 class PendingTransaction(BaseModel):
     tipo: str = "despesa"
-    categoria: str = "outros"
+    categoria: str = "Outros"
     valor: float
 
 

--- a/app/services/budgets.py
+++ b/app/services/budgets.py
@@ -11,15 +11,15 @@ BUDGET_EDIT_WORDS = {"alterar", "adicionar", "ajustar", "mudar", "editar", "revi
 BUDGET_CONTEXT_WORDS = {"budget", "orcamento", "limite", "limites", "categoria", "categorias"}
 
 CATEGORY_ALIASES = {
-    "farmacia": "farmacia",
-    "mercado": "mercado",
-    "supermercado": "mercado",
-    "alimentacao": "alimentacao",
-    "alimentacao ": "alimentacao",
-    "lazer": "lazer",
-    "transporte": "transporte",
-    "moradia": "moradia",
-    "saude": "saude",
+    "farmacia": "Farmacia",
+    "mercado": "Mercado",
+    "supermercado": "Mercado",
+    "alimentacao": "Alimentacao",
+    "alimentacao ": "Alimentacao",
+    "lazer": "Lazer",
+    "transporte": "Transporte",
+    "moradia": "Moradia",
+    "saude": "Saude",
 }
 
 ALERT_LEVELS = (

--- a/app/services/chat.py
+++ b/app/services/chat.py
@@ -17,10 +17,10 @@ from app.services.summary import gerar_insight
 logger = get_logger("navi.chat")
 
 REGRAS_CATEGORIAS = {
-    "alimentacao": ["ifood", "restaurante", "lanche", "pizza", "hamburguer"],
-    "transporte": ["uber", "99", "taxi", "gasolina", "combustivel"],
-    "moradia": ["aluguel", "condominio", "luz", "agua"],
-    "lazer": ["cinema", "netflix", "spotify", "bar"],
+    "Alimentacao": ["ifood", "restaurante", "lanche", "pizza", "hamburguer"],
+    "Transporte": ["uber", "99", "taxi", "gasolina", "combustivel"],
+    "Moradia": ["aluguel", "condominio", "luz", "agua"],
+    "Lazer": ["cinema", "netflix", "spotify", "bar"],
 }
 
 

--- a/app/services/conversation.py
+++ b/app/services/conversation.py
@@ -36,13 +36,27 @@ QUERY_BUDGET_PATTERNS = (
 QUERY_INVOICE_PATTERNS = (
     "qual o valor da minha fatura",
     "qual o valor da fatura",
+    "valor atual da fatura",
+    "valor da fatura",
     "quanto esta a fatura",
     "quanto está a fatura",
-    "valor da fatura",
+    "quanto é a fatura",
+    "quanto e a fatura",
+    "qual e a fatura",
+    "qual é a fatura",
     "minha fatura do",
+    "minha fatura esta",
+    "minha fatura está",
+    "fatura do meu",
+    "fatura atual do",
     "fatura do santander",
     "fatura do bradesco",
     "fatura do nubank",
+    "fatura do itau",
+    "fatura do inter",
+    "consultar fatura",
+    "ver fatura",
+    "checar fatura",
 )
 
 QUERY_FINANCIAL_HEALTH_PATTERNS = (

--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -394,14 +394,84 @@ def _score_page_financial_density(text: str) -> int:
     )
 
 
-def _extract_pdf_text(media_bytes: bytes) -> str:
+def _extract_pdfplumber_page(page: Any) -> str:
+    """
+    Extract text from a pdfplumber page preserving table row structure.
+
+    Tries line-based then text-based table detection so that multi-column
+    transaction tables (Date | Description | Debit | Credit | Balance) are
+    returned as pipe-separated rows instead of spatially-scrambled text.
+    Falls back to plain extract_text() when no usable table is detected.
+    """
+    for table_settings in (
+        {"vertical_strategy": "lines", "horizontal_strategy": "lines"},
+        {"vertical_strategy": "text", "horizontal_strategy": "text"},
+    ):
+        try:
+            tables = page.extract_tables(table_settings)
+        except Exception:
+            tables = []
+        if not tables:
+            continue
+        rows: list[str] = []
+        for table in tables:
+            for row in table:
+                if not row:
+                    continue
+                cells = [str(cell or "").strip().replace("\n", " ") for cell in row]
+                if sum(1 for c in cells if c) >= 2:
+                    rows.append(" | ".join(cells))
+        if len(rows) >= 2:
+            return "\n".join(rows)
+
+    text = page.extract_text() or ""
+    return re.sub(r"\s+\n", "\n", text).strip()
+
+
+def _get_pdf_pages_text(media_bytes: bytes) -> tuple[list[tuple[int, str]], int]:
+    """
+    Extract text from every page, returning ([(page_index, text), ...], total_pages).
+
+    Prefers pdfplumber for its superior table-aware extraction; falls back to
+    pypdf when pdfplumber is not installed.
+    """
+    try:
+        import pdfplumber  # noqa: PLC0415
+
+        indexed: list[tuple[int, str]] = []
+        with pdfplumber.open(BytesIO(media_bytes)) as pdf:
+            total_pages = len(pdf.pages)
+            for i, page in enumerate(pdf.pages):
+                text = _extract_pdfplumber_page(page)
+                if text:
+                    indexed.append((i, text))
+        logger.debug(
+            "pdf_pages_extracted total=%d extracted=%d method=pdfplumber",
+            total_pages,
+            len(indexed),
+        )
+        return indexed, total_pages
+    except ImportError:
+        pass
+
     reader = PdfReader(BytesIO(media_bytes))
-    pages: list[str] = []
-    for page in reader.pages:
-        text = page.extract_text() or ""
-        text = re.sub(r"\s+\n", "\n", text)
-        pages.append(text.strip())
-    return "\n\n".join(part for part in pages if part).strip()
+    total_pages = len(reader.pages)
+    indexed = []
+    for i, page in enumerate(reader.pages):
+        text = re.sub(r"\s+\n", "\n", page.extract_text() or "").strip()
+        if text:
+            indexed.append((i, text))
+    logger.debug(
+        "pdf_pages_extracted total=%d extracted=%d method=pypdf",
+        total_pages,
+        len(indexed),
+    )
+    return indexed, total_pages
+
+
+def _extract_pdf_text(media_bytes: bytes) -> str:
+    indexed, _ = _get_pdf_pages_text(media_bytes)
+    return "\n\n".join(text for _, text in indexed)
 
 
 def _get_pdf_text_for_prompt(media_bytes: bytes) -> tuple[str, int, int]:
@@ -413,15 +483,7 @@ def _get_pdf_text_for_prompt(media_bytes: bytes) -> tuple[str, int, int]:
       - first page (header, account info) and last page (totals/summary) are always included;
       - remaining budget is filled with middle pages ranked by financial data density.
     """
-    reader = PdfReader(BytesIO(media_bytes))
-    total_pages = len(reader.pages)
-
-    indexed: list[tuple[int, str]] = []
-    for i, page in enumerate(reader.pages):
-        text = page.extract_text() or ""
-        text = re.sub(r"\s+\n", "\n", text).strip()
-        if text:
-            indexed.append((i, text))
+    indexed, total_pages = _get_pdf_pages_text(media_bytes)
 
     if not indexed:
         return "", 0, total_pages

--- a/app/services/onboarding.py
+++ b/app/services/onboarding.py
@@ -99,13 +99,13 @@ VARIABLE_COST_KEYWORDS = (
 )
 
 COST_CATEGORY_KEYWORDS = {
-    "moradia": ("aluguel", "condominio", "condomínio", "agua", "água", "gas", "gás", "energia", "luz"),
-    "saude": ("farmacia", "farmácia", "seguro", "plano", "consulta", "medico", "médico"),
-    "alimentacao": ("mercado", "supermercado", "ifood", "restaurante", "padaria", "cantina"),
-    "transporte": ("uber", "combustivel", "combustível", "posto", "99", "pedagio", "pedágio"),
-    "comunicacao": ("telefone", "vivo", "claro", "tim", "internet"),
-    "financeiro": ("boleto", "juros", "iof", "tarifa", "financiamento", "parcela"),
-    "lazer": ("lazer", "cinema", "show", "streaming", "loterias"),
+    "Moradia": ("aluguel", "condominio", "condomínio", "agua", "água", "gas", "gás", "energia", "luz"),
+    "Saude": ("farmacia", "farmácia", "seguro", "plano", "consulta", "medico", "médico"),
+    "Alimentacao": ("mercado", "supermercado", "ifood", "restaurante", "padaria", "cantina"),
+    "Transporte": ("uber", "combustivel", "combustível", "posto", "99", "pedagio", "pedágio"),
+    "Comunicacao": ("telefone", "vivo", "claro", "tim", "internet"),
+    "Financeiro": ("boleto", "juros", "iof", "tarifa", "financiamento", "parcela"),
+    "Lazer": ("lazer", "cinema", "show", "streaming", "loterias"),
 }
 
 GENERIC_COST_TOKENS = {
@@ -839,7 +839,7 @@ def infer_cost_candidates(user_id: int) -> tuple[list[dict[str, float | str]], l
             "descricao": description,
             "valor": amount,
             "tipo_custo": cost_type,
-            "categoria": _classify_cost_category(description) or "outros",
+            "categoria": _classify_cost_category(description) or "Outros",
         }
         if cost_type == "fixo":
             fixed_costs.append(payload)
@@ -1414,7 +1414,7 @@ def infer_invoice_cost_candidates(user_id: int) -> tuple[list[dict[str, float | 
             "descricao": description,
             "valor": amount,
             "tipo_custo": cost_type,
-            "categoria": _classify_cost_category(description) or "outros",
+            "categoria": _classify_cost_category(description) or "Outros",
         }
         if cost_type == "fixo":
             fixed_costs.append(payload)


### PR DESCRIPTION
## Problema

O PR #70 causou falha no `init_db` ao iniciar o servidor. O `SCHEMA_STATEMENTS` executava:

1. **INSERT** `'Alimentacao'` → cria linha nova (pois `'alimentacao' ≠ 'Alimentacao'` — constraint UNIQUE é case-sensitive)
2. **UPDATE** `'alimentacao' → 'Alimentacao'` → viola `UNIQUE(nome)` porque já existia `'Alimentacao'`

O erro não é `OperationalError`, então não era capturado pelo retry loop — servidor não subia.

## Fix

Inverter a ordem: UPDATE antes do INSERT.

- UPDATE renomeia as linhas lowercase existentes → `'Alimentacao'`
- INSERT ON CONFLICT DO NOTHING → pula silenciosamente (já existe)

Em DBs vazios: UPDATE não faz nada, INSERT cria as linhas. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)