### PR TITLE
fix: improve invoice processing feedback and proactive message after analysis

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -425,6 +425,10 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
 
     if onboarding_state == COST_REVIEW_PENDING:
         is_post_cards = bool(existing_card_names)
+        if is_post_cards and is_document_processing(user_id):
+            resposta = "Ainda estou processando sua fatura, aguarde um momento..."
+            return Response(content=build_twiml(resposta), media_type="application/xml")
+
         if is_post_cards:
             fixed_costs, variable_costs = infer_invoice_cost_candidates(user_id)
         else:
@@ -612,29 +616,26 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
                 return Response(content=build_twiml(resposta), media_type="application/xml")
 
             if incoming_media:
-                _register_document_upload("fatura_cartao")
                 next_card = advance_card_progress(user_id)
                 if next_card:
+                    _register_document_upload("fatura_cartao")
                     resposta = (
                         f"Perfeito. Já deixei a fatura do {current_card['nome_cartao']} salva por aqui.\n\n"
                         "Isso já me ajuda a acompanhar melhor esse cartão e a deixar sua base financeira mais redonda.\n\n"
                         f"Agora me manda a fatura atual do {next_card['nome_cartao']}."
                     )
                 else:
-                    set_onboarding_state(user_id, COST_REVIEW_PENDING)
-                    invoice_fixed, invoice_variable = infer_invoice_cost_candidates(user_id)
                     card_name_display = str(current_card["nome_cartao"])
-                    if invoice_fixed or invoice_variable:
-                        resposta = (
-                            f"Perfeito. Já deixei a fatura do {card_name_display} salva por aqui.\n\n"
-                            f"{cost_review_prompt(invoice_fixed, invoice_variable)}"
-                        )
-                    else:
-                        resposta = (
-                            f"Perfeito. Já deixei a fatura do {card_name_display} salva por aqui.\n\n"
-                            "Estou analisando os lançamentos em segundo plano. "
-                            "Me responda qualquer coisa para eu te mostrar o que identifiquei."
-                        )
+                    set_onboarding_state(user_id, COST_REVIEW_PENDING)
+                    _register_document_upload(
+                        "fatura_cartao",
+                        on_complete_numero=numero,
+                    )
+                    resposta = (
+                        f"Recebi sua fatura do {card_name_display}. "
+                        "Estou analisando os lançamentos agora, isso leva alguns instantes...\n\n"
+                        "Assim que terminar, te mando o que identifiquei."
+                    )
                 return Response(content=build_twiml(resposta), media_type="application/xml")
 
             if should_skip_document_onboarding(mensagem):


### PR DESCRIPTION
## Summary

- Replaces confusing "Me responda qualquer coisa para eu te mostrar o que identifiquei" with a clear "Recebi sua fatura. Estou analisando os lançamentos agora..."
- After background processing completes, sends a proactive WhatsApp message via `responder()` with the full invoice analysis (`_build_analysis_message`)
- Adds `is_document_processing()` guard at the top of `COST_REVIEW_PENDING` for the post-cards path: if invoice is still being processed, responds "Ainda estou processando sua fatura, aguarde um momento..."
- Reorders `advance_card_progress()` call to happen before `_register_document_upload()` so the `on_complete_numero` callback is only set for the last card

Fixes #77

## Test plan

- [ ] Upload last invoice in CARD_INVOICE_PENDING → receive "Recebi sua fatura. Estou analisando..." immediately
- [ ] Send any message while invoice is being processed (COST_REVIEW_PENDING) → receive "Ainda estou processando..." 
- [ ] After background completes → receive proactive WhatsApp message with invoice analysis
- [ ] Reply to proactive message → COST_REVIEW_PENDING handler shows cost review prompt with identified costs
- [ ] Non-last card invoices → unchanged behavior (no proactive callback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)