### PR TITLE
fix: debug and fix proactive message delivery after background document processing

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -425,6 +425,10 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
 
     if onboarding_state == COST_REVIEW_PENDING:
         is_post_cards = bool(existing_card_names)
+        if is_post_cards and is_document_processing(user_id):
+            resposta = "Ainda estou processando sua fatura, aguarde um momento..."
+            return Response(content=build_twiml(resposta), media_type="application/xml")
+
         if is_post_cards:
             fixed_costs, variable_costs = infer_invoice_cost_candidates(user_id)
         else:
@@ -612,29 +616,26 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
                 return Response(content=build_twiml(resposta), media_type="application/xml")
 
             if incoming_media:
-                _register_document_upload("fatura_cartao")
                 next_card = advance_card_progress(user_id)
                 if next_card:
+                    _register_document_upload("fatura_cartao")
                     resposta = (
                         f"Perfeito. Já deixei a fatura do {current_card['nome_cartao']} salva por aqui.\n\n"
                         "Isso já me ajuda a acompanhar melhor esse cartão e a deixar sua base financeira mais redonda.\n\n"
                         f"Agora me manda a fatura atual do {next_card['nome_cartao']}."
                     )
                 else:
-                    set_onboarding_state(user_id, COST_REVIEW_PENDING)
-                    invoice_fixed, invoice_variable = infer_invoice_cost_candidates(user_id)
                     card_name_display = str(current_card["nome_cartao"])
-                    if invoice_fixed or invoice_variable:
-                        resposta = (
-                            f"Perfeito. Já deixei a fatura do {card_name_display} salva por aqui.\n\n"
-                            f"{cost_review_prompt(invoice_fixed, invoice_variable)}"
-                        )
-                    else:
-                        resposta = (
-                            f"Perfeito. Já deixei a fatura do {card_name_display} salva por aqui.\n\n"
-                            "Estou analisando os lançamentos em segundo plano. "
-                            "Me responda qualquer coisa para eu te mostrar o que identifiquei."
-                        )
+                    set_onboarding_state(user_id, COST_REVIEW_PENDING)
+                    _register_document_upload(
+                        "fatura_cartao",
+                        on_complete_numero=numero,
+                    )
+                    resposta = (
+                        f"Recebi sua fatura do {card_name_display}. "
+                        "Estou analisando os lançamentos agora, isso leva alguns instantes...\n\n"
+                        "Assim que terminar, te mando o que identifiquei."
+                    )
                 return Response(content=build_twiml(resposta), media_type="application/xml")
 
             if should_skip_document_onboarding(mensagem):

--- a/app/main.py
+++ b/app/main.py
@@ -161,6 +161,15 @@ def healthcheck() -> dict[str, str]:
     return {"status": status, "environment": settings.app_env, "database": db_status}
 
 
+@app.post("/debug/test-responder")
+def debug_test_responder(numero: str, mensagem: str) -> dict[str, str]:
+    try:
+        responder(numero, mensagem)
+        return {"status": "ok", "to": numero}
+    except Exception as exc:
+        return {"status": "error", "to": numero, "detail": str(exc)}
+
+
 @app.post("/webhook")
 async def webhook(request: Request, background_tasks: BackgroundTasks) -> Response:
     form = await request.form()

--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -1659,13 +1659,36 @@ def process_stored_document(
         if on_complete_numero:
             from app.services.onboarding import set_onboarding_state
             from app.services.twilio import responder
+            import time as _time
             if on_complete_state:
                 set_onboarding_state(user_id, on_complete_state)
             proactive_msg = _build_analysis_message(analysis, hinted_type)
-            try:
-                responder(on_complete_numero, proactive_msg)
-            except Exception:
-                logger.exception("doc_proactive_send_error document_id=%d user_id=%d", document_id, user_id)
+            logger.info(
+                "doc_proactive_attempt document_id=%d user_id=%d numero=%s msg_len=%d",
+                document_id, user_id, on_complete_numero, len(proactive_msg),
+            )
+            _sent = False
+            for _attempt, _delay in enumerate([0, 1, 2], 1):
+                if _delay:
+                    _time.sleep(_delay)
+                try:
+                    responder(on_complete_numero, proactive_msg)
+                    logger.info(
+                        "doc_proactive_ok document_id=%d user_id=%d attempt=%d",
+                        document_id, user_id, _attempt,
+                    )
+                    _sent = True
+                    break
+                except Exception:
+                    logger.exception(
+                        "doc_proactive_error document_id=%d user_id=%d attempt=%d",
+                        document_id, user_id, _attempt,
+                    )
+            if not _sent:
+                logger.error(
+                    "doc_proactive_all_attempts_failed document_id=%d user_id=%d",
+                    document_id, user_id,
+                )
     else:
         logger.warning("doc_processing_no_analysis document_id=%d user_id=%d", document_id, user_id)
 

--- a/app/services/twilio.py
+++ b/app/services/twilio.py
@@ -1,27 +1,72 @@
 import requests
 
 from app.config import get_settings
+from app.services.logger import get_logger
+
+logger = get_logger("navi.twilio")
 
 _WHATSAPP_MAX_CHARS = 1500
+
+
+def _normalize_whatsapp_number(numero: str) -> str:
+    cleaned = (
+        numero.strip()
+        .replace(" ", "")
+        .replace("(", "")
+        .replace(")", "")
+        .replace("-", "")
+    )
+    if cleaned.lower().startswith("whatsapp:"):
+        number_part = cleaned[len("whatsapp:"):]
+    else:
+        number_part = cleaned
+    if not number_part.startswith("+"):
+        number_part = "+" + number_part
+    return "whatsapp:" + number_part
 
 
 def responder(numero: str, mensagem: str) -> None:
     settings = get_settings()
     if not settings.account_sid or not settings.auth_token or not settings.twilio_number:
+        logger.error(
+            "twilio_credentials_missing account_sid=%s twilio_number=%s",
+            bool(settings.account_sid),
+            bool(settings.twilio_number),
+        )
         return
 
+    normalized = _normalize_whatsapp_number(numero)
     url = (
         f"https://api.twilio.com/2010-04-01/Accounts/"
         f"{settings.account_sid}/Messages.json"
     )
-
     data = {
         "From": settings.twilio_number,
-        "To": numero,
-        "Body": mensagem,
+        "To": normalized,
+        "Body": mensagem[:_WHATSAPP_MAX_CHARS],
     }
 
-    requests.post(url, data=data, auth=(settings.account_sid, settings.auth_token), timeout=15)
+    logger.info(
+        "twilio_send_attempt to=%s from=%s body_len=%d",
+        normalized,
+        settings.twilio_number,
+        len(mensagem),
+    )
+
+    resp = requests.post(
+        url, data=data, auth=(settings.account_sid, settings.auth_token), timeout=15
+    )
+
+    if resp.status_code >= 400:
+        logger.error(
+            "twilio_send_failed to=%s status=%d body=%s",
+            normalized,
+            resp.status_code,
+            resp.text[:500],
+        )
+        resp.raise_for_status()
+
+    logger.info("twilio_send_ok to=%s status=%d", normalized, resp.status_code)
 
 
 def _split_message(text: str, max_len: int = _WHATSAPP_MAX_CHARS) -> list[str]:


### PR DESCRIPTION
## Summary

- **`twilio.py::responder()`**: adicionados logs de tentativa e resultado, checagem de status HTTP (`raise_for_status` em 4xx/5xx), log de erro explícito quando credenciais estiverem ausentes, e normalização do número WhatsApp (`_normalize_whatsapp_number`) que garante prefixo `whatsapp:+` preservando DDD e país originais
- **`documents.py::process_stored_document()`**: logs de diagnóstico antes e após a chamada a `responder()`, retry com backoff exponencial (0s → 1s → 2s, 3 tentativas), log de erro se todas as tentativas falharem
- **`main.py`**: endpoint `POST /debug/test-responder?numero=...&mensagem=...` para validar `responder()` fora do contexto de background task

### Root cause suspeito
`responder()` não logava nada e engolia silenciosamente qualquer falha HTTP (credenciais inválidas, formato de número errado, timeout). A ausência de `raise_for_status()` fazia o caller achar que o envio teve sucesso quando na verdade falhou.

Fixes #80

## Test plan

- [ ] Chamar `POST /debug/test-responder?numero=whatsapp:+55119...&mensagem=teste` → receber mensagem no WhatsApp
- [ ] Verificar logs: `twilio_send_attempt`, `twilio_send_ok` presentes após upload de extrato
- [ ] Se credenciais incorretas → log `twilio_credentials_missing` ou `twilio_send_failed` visível nos logs
- [ ] Após upload de extrato em onboarding → mensagem proativa chega no WhatsApp sem precisar enviar outra mensagem
- [ ] Verificar que número `whatsapp:+5511...` não é alterado; `+5531...` vira `whatsapp:+5531...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)