### PR TITLE
fix: filter non-transactional lines like Saldo Anterior from statement analysis

### DIFF
--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -215,17 +215,52 @@ def _normalize_statement_entries(entries: Any) -> list[dict[str, Any]]:
     return normalized_entries
 
 
+_NON_TRANSACTION_EXACT = frozenset({
+    "total",
+    "subtotal",
+    "saldo",
+})
+
+_NON_TRANSACTION_PREFIXES = (
+    "saldo anterior",
+    "saldo atual",
+    "saldo disponivel",
+    "saldo do periodo",
+    "saldo do dia",
+    "saldo inicial",
+    "saldo final",
+    "saldo em ",
+    "saldo periodo",
+)
+
+
+def _ascii_lower(text: str) -> str:
+    return unicodedata.normalize("NFKD", text.lower()).encode("ascii", "ignore").decode("ascii")
+
+
+def _is_non_transactional(description: str) -> bool:
+    d = _ascii_lower(description)
+    if d in _NON_TRANSACTION_EXACT:
+        return True
+    return any(d.startswith(prefix) for prefix in _NON_TRANSACTION_PREFIXES)
+
+
 def _normalize_statement_rows(rows: Any) -> list[dict[str, Any]]:
     if not isinstance(rows, list):
         return []
 
     normalized_rows: list[dict[str, Any]] = []
+    filtered_count = 0
     for row in rows[:200]:
         if not isinstance(row, dict):
             continue
 
         description = str(row.get("description") or "").strip()
         if not description:
+            continue
+
+        if _is_non_transactional(description):
+            filtered_count += 1
             continue
 
         credit = _safe_float(row.get("credit"))
@@ -263,6 +298,9 @@ def _normalize_statement_rows(rows: Any) -> list[dict[str, Any]]:
                 "confirmado": False,
             }
         )
+
+    if filtered_count:
+        logger.info("doc_filtered_non_transactions count=%d", filtered_count)
 
     return normalized_rows
 


### PR DESCRIPTION
## Summary

- Adiciona `_is_non_transactional(description)` que normaliza a descrição (ASCII lowercase) e verifica contra lista de prefixos/exatos não-transacionais
- `_normalize_statement_rows()` agora descarta silenciosamente linhas como "Saldo Anterior", "Saldo Atual", "Saldo Disponível", "Total", "Subtotal" antes de incluí-las na lista de lançamentos
- Log `doc_filtered_non_transactions count=X` registra quantas linhas foram descartadas em cada extração
- Filtros cobrem variantes com e sem acento (normalização NFKD→ASCII)

Fixes #86

## Test plan

- [ ] Upload de extrato com linha "Saldo Anterior" → não aparece na lista de lançamentos
- [ ] Upload de extrato com linha "Saldo Atual" → não aparece
- [ ] Transações legítimas com palavras como "RENDIMENTO APLICACAO" → não são filtradas
- [ ] Log `doc_filtered_non_transactions count=1` aparece quando há linhas descartadas

🤖 Generated with [Claude Code](https://claude.com/claude-code)