### PR TITLE
feat: add subcategory support to transactions and monthly costs

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -237,6 +237,14 @@ SCHEMA_STATEMENTS = (
     UPDATE categorias SET nome = INITCAP(nome)
     WHERE nome ~ '^[a-z]'
     """,
+    """
+    ALTER TABLE transacoes
+    ADD COLUMN IF NOT EXISTS subcategoria VARCHAR(100) NULL
+    """,
+    """
+    ALTER TABLE custos_mensais
+    ADD COLUMN IF NOT EXISTS subcategoria VARCHAR(100) NULL
+    """,
 )
 
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -13,12 +13,14 @@ class Message(BaseModel):
 class ParsedTransaction(BaseModel):
     tipo: str = "despesa"
     categoria: str = "Outros"
+    subcategoria: str | None = None
     valor: float = 0
 
 
 class PendingTransaction(BaseModel):
     tipo: str = "despesa"
     categoria: str = "Outros"
+    subcategoria: str | None = None
     valor: float
 
 

--- a/app/services/chat.py
+++ b/app/services/chat.py
@@ -88,7 +88,7 @@ def _extract_transactions_from_ai(text: str) -> list[ParsedTransaction]:
                     'Classifique a mensagem:\n\n'
                     f'"{text}"\n\n'
                     "Retorne uma lista de objetos no formato:\n"
-                    '[{"tipo":"receita ou despesa","categoria":"categoria","valor":numero}]'
+                    '[{"tipo":"receita ou despesa","categoria":"categoria","subcategoria":"subcategoria especifica ou null","valor":numero}]'
                 ),
             },
         ],
@@ -111,7 +111,8 @@ def _normalize_transaction(text: str, transaction: ParsedTransaction) -> Pending
     categoria_regra = classificar_categoria(text)
     categoria = categoria_regra or _normalizar_texto(transaction.categoria or "outros")
     tipo = _normalizar_texto(transaction.tipo or "despesa")
-    return PendingTransaction(tipo=tipo, categoria=categoria, valor=float(transaction.valor))
+    subcategoria = transaction.subcategoria.strip() if transaction.subcategoria else None
+    return PendingTransaction(tipo=tipo, categoria=categoria, subcategoria=subcategoria, valor=float(transaction.valor))
 
 
 def _build_confirmation_message(transaction: PendingTransaction) -> str:
@@ -169,13 +170,14 @@ def process_user_message(text: str, user_id: int) -> dict[str, str]:
         for transaction in normalized_transactions:
             cursor.execute(
                 """
-                INSERT INTO transacoes (tipo, categoria, valor, user_id)
-                VALUES (%s, %s, %s, %s)
+                INSERT INTO transacoes (tipo, categoria, subcategoria, valor, user_id)
+                VALUES (%s, %s, %s, %s, %s)
                 """,
-                (transaction.tipo, transaction.categoria, transaction.valor, user_id),
+                (transaction.tipo, transaction.categoria, transaction.subcategoria, transaction.valor, user_id),
             )
 
-            respostas.append(f"- {transaction.categoria}: {format_brl(transaction.valor)}")
+            cat_display = f"{transaction.categoria}/{transaction.subcategoria}" if transaction.subcategoria else transaction.categoria
+            respostas.append(f"- {cat_display}: {format_brl(transaction.valor)}")
             ultima_categoria = transaction.categoria
 
         conn.commit()

--- a/app/services/conversation.py
+++ b/app/services/conversation.py
@@ -254,17 +254,18 @@ def confirm_pending_transaction(user_id: int) -> dict[str, str]:
     with get_cursor() as (conn, cursor):
         cursor.execute(
             """
-            INSERT INTO transacoes (tipo, categoria, valor, user_id)
-            VALUES (%s, %s, %s, %s)
+            INSERT INTO transacoes (tipo, categoria, subcategoria, valor, user_id)
+            VALUES (%s, %s, %s, %s, %s)
             """,
-            (pending.tipo, pending.categoria, pending.valor, user_id),
+            (pending.tipo, pending.categoria, pending.subcategoria, pending.valor, user_id),
         )
         cursor.execute("DELETE FROM confirmacoes_pendentes WHERE user_id = %s", (user_id,))
         conn.commit()
 
+    cat_display = f"{pending.categoria}/{pending.subcategoria}" if pending.subcategoria else pending.categoria
     resposta = (
         "Transacao confirmada:\n\n"
-        f"- {pending.categoria}: R${pending.valor:.2f}"
+        f"- {cat_display}: R${pending.valor:.2f}"
     )
     budget_feedback = build_budget_feedback(user_id, pending.categoria)
     if budget_feedback:

--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -192,6 +192,7 @@ def _statement_extraction_instructions() -> str:
         "tipo_custo ('fixo' para recorrentes mensais, 'variavel' para gastos pontuais, "
         "'rendimento' para creditos de investimento/aplicacao, 'credito' para outros creditos), "
         "categoria_sugerida (use uma das categorias disponiveis ou 'Outros'), "
+        "subcategoria_sugerida (subcategoria especifica quando identificavel, ex: 'supermercado', 'uber', 'academia', ou null), "
         "confirmado (sempre false na primeira analise). "
         "debit_entries: TODOS os debitos — compras, PIX enviados, tarifas, qualquer saida. "
         "credit_entries: TODOS os creditos — rendimentos, aplicacoes, estornos, transferencias, qualquer entrada."
@@ -283,6 +284,7 @@ def _normalize_statement_rows(rows: Any) -> list[dict[str, Any]]:
         tipo_custo_raw = str(row.get("tipo_custo") or "").strip().lower()
         tipo_custo = tipo_custo_raw if tipo_custo_raw in {"fixo", "variavel", "rendimento", "credito"} else "variavel"
         categoria_sugerida = str(row.get("categoria_sugerida") or "Outros").strip() or "Outros"
+        subcategoria_sugerida = str(row.get("subcategoria_sugerida") or "").strip() or None
 
         normalized_rows.append(
             {
@@ -295,6 +297,7 @@ def _normalize_statement_rows(rows: Any) -> list[dict[str, Any]]:
                 "confidence": confidence if confidence in {"high", "medium", "low"} else "medium",
                 "tipo_custo": tipo_custo,
                 "categoria_sugerida": categoria_sugerida,
+                "subcategoria_sugerida": subcategoria_sugerida,
                 "confirmado": False,
             }
         )
@@ -667,7 +670,7 @@ def _build_document_analysis_system_prompt(income_instructions: str, hinted_type
         '"account_limit":numero ou null,'
         '"pending_charges":numero ou null,'
         '"charges_debit_date":"YYYY-MM-DD" ou null,'
-        '"statement_rows":[{"date":"YYYY-MM-DD ou texto","description":"texto EXATAMENTE como no documento","credit":numero ou null,"debit":numero ou null,"balance":numero ou null,"raw_amount_text":"texto ou null","confidence":"high|medium|low","tipo_custo":"fixo|variavel|rendimento|credito","categoria_sugerida":"nome da categoria ou Outros","confirmado":false}] — INCLUA ABSOLUTAMENTE TODOS os lancamentos sem filtrar,'
+        '"statement_rows":[{"date":"YYYY-MM-DD ou texto","description":"texto EXATAMENTE como no documento","credit":numero ou null,"debit":numero ou null,"balance":numero ou null,"raw_amount_text":"texto ou null","confidence":"high|medium|low","tipo_custo":"fixo|variavel|rendimento|credito","categoria_sugerida":"nome da categoria ou Outros","subcategoria_sugerida":"subcategoria especifica ou null","confirmado":false}] — INCLUA ABSOLUTAMENTE TODOS os lancamentos sem filtrar,'
         '"credit_entries":[{"date":"YYYY-MM-DD ou texto","description":"texto","amount":numero}] (TODOS os creditos: remuneracao de aplicacao, rendimento, estorno, transferencia — mesmo R$0,01),'
         '"debit_entries":[{"date":"YYYY-MM-DD ou texto","description":"texto","amount":numero}] (TODOS os debitos: cartao de debito, PIX enviado, tarifa, compra — mesmo valores pequenos),'
         '"estimated_fixed_expenses":numero ou null,'
@@ -1539,7 +1542,9 @@ def _build_analysis_message(analysis: dict[str, Any], fallback_type: str) -> str
                     valor_str = ""
                 tipo = row.get("tipo_custo") or ""
                 cat = row.get("categoria_sugerida") or ""
-                meta = " | ".join(part for part in [tipo, cat] if part)
+                subcat = row.get("subcategoria_sugerida") or ""
+                cat_display = f"{cat}/{subcat}" if cat and subcat else cat
+                meta = " | ".join(part for part in [tipo, cat_display] if part)
                 suffix = f" ({meta})" if meta else ""
                 val_part = f": {valor_str}" if valor_str else ""
                 lines.append(f"- {date_prefix}{row['description']}{val_part}{suffix}")

--- a/app/services/onboarding.py
+++ b/app/services/onboarding.py
@@ -883,18 +883,18 @@ def save_cost_candidates(
                 for item in fixed_costs:
                     cursor.execute(
                         """
-                        INSERT INTO custos_mensais (user_id, descricao, categoria, valor_medio, tipo_custo, confirmado, origem)
-                        VALUES (%s, %s, %s, %s, 'fixo', TRUE, %s)
+                        INSERT INTO custos_mensais (user_id, descricao, categoria, subcategoria, valor_medio, tipo_custo, confirmado, origem)
+                        VALUES (%s, %s, %s, %s, %s, 'fixo', TRUE, %s)
                         """,
-                        (user_id, item["descricao"], item.get("categoria"), item["valor"], origem),
+                        (user_id, item["descricao"], item.get("categoria"), item.get("subcategoria"), item["valor"], origem),
                     )
                 for item in variable_costs:
                     cursor.execute(
                         """
-                        INSERT INTO custos_mensais (user_id, descricao, categoria, valor_medio, tipo_custo, confirmado, origem)
-                        VALUES (%s, %s, %s, %s, 'variavel', TRUE, %s)
+                        INSERT INTO custos_mensais (user_id, descricao, categoria, subcategoria, valor_medio, tipo_custo, confirmado, origem)
+                        VALUES (%s, %s, %s, %s, %s, 'variavel', TRUE, %s)
                         """,
-                        (user_id, item["descricao"], item.get("categoria"), item["valor"], origem),
+                        (user_id, item["descricao"], item.get("categoria"), item.get("subcategoria"), item["valor"], origem),
                     )
 
         if _column_exists(cursor, "configuracoes_usuario", "custos_onboarding_concluido"):


### PR DESCRIPTION
## Summary

- **`db.py`**: `ALTER TABLE transacoes ADD COLUMN IF NOT EXISTS subcategoria VARCHAR(100) NULL` e idem em `custos_mensais`
- **`schemas.py`**: campo `subcategoria: str | None = None` em `ParsedTransaction` e `PendingTransaction`
- **`documents.py`**: `_normalize_statement_rows` captura `subcategoria_sugerida` do GPT; system prompt e `_statement_extraction_instructions` atualizados para solicitar `subcategoria_sugerida`; `_build_analysis_message` exibe `categoria/subcategoria` quando subcategoria existe
- **`chat.py`**: prompt GPT solicita `subcategoria`; `_normalize_transaction` propaga campo; INSERT em `transacoes` inclui `subcategoria`; resposta exibe `categoria/subcategoria`
- **`conversation.py`**: `confirm_pending_transaction` inclui `subcategoria` no INSERT e na resposta
- **`onboarding.py`**: `save_cost_candidates` inclui `subcategoria` nos INSERTs em `custos_mensais`

Fixes #85

## Test plan

- [ ] "Gastei R$50 no Mercado Pão de Açúcar" → registro com `categoria=Alimentacao, subcategoria=supermercado`
- [ ] Upload de extrato → lançamentos exibem `Alimentacao/supermercado`, `Moradia/agua` etc.
- [ ] Custos mensais salvos com subcategoria quando disponível
- [ ] Startup do app aplica migrations sem erro (colunas já existem → `IF NOT EXISTS` ignora)

🤖 Generated with [Claude Code](https://claude.com/claude-code)