### PR TITLE
fix: skip duplicate cost review when statement was already reviewed

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -245,6 +245,10 @@ SCHEMA_STATEMENTS = (
     ALTER TABLE custos_mensais
     ADD COLUMN IF NOT EXISTS subcategoria VARCHAR(100) NULL
     """,
+    """
+    ALTER TABLE documentos_financeiros
+    ADD COLUMN IF NOT EXISTS revisado BOOLEAN NOT NULL DEFAULT FALSE
+    """,
 )
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -45,6 +45,7 @@ from app.services.documents import (
     is_invoice_followup_message,
     is_document_onboarding_completed,
     is_waiting_for_document,
+    mark_extrato_reviewed,
     process_stored_document,
     register_received_document,
     save_extrato_adjustments,
@@ -95,6 +96,7 @@ from app.services.onboarding import (
     is_confirmation_no,
     is_confirmation_yes,
     is_cost_review_completed,
+    is_statement_already_reviewed,
     parse_card_count,
     parse_card_names_llm_first,
     parse_balance_message,
@@ -324,6 +326,7 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
             return Response(content=build_twiml(resposta), media_type="application/xml")
 
         if is_confirmation_yes(msg_lower):
+            mark_extrato_reviewed(user_id)
             set_onboarding_state(user_id, BUDGET_SETUP_PENDING)
             resposta = (
                 "Ótimo! Lançamentos confirmados.\n\n"
@@ -454,6 +457,14 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
         is_post_cards = bool(existing_card_names)
         if is_post_cards and is_document_processing(user_id):
             resposta = "Ainda estou processando sua fatura, aguarde um momento..."
+            return Response(content=build_twiml(resposta), media_type="application/xml")
+
+        if not is_post_cards and is_statement_already_reviewed(user_id):
+            set_onboarding_state(user_id, CARD_COUNT_PENDING)
+            resposta = (
+                "Seus lançamentos já foram organizados. Seguindo em frente...\n\n"
+                f"{card_count_prompt()}"
+            )
             return Response(content=build_twiml(resposta), media_type="application/xml")
 
         if is_post_cards:

--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -1828,6 +1828,25 @@ def save_extrato_adjustments(user_id: int, updated_rows: list[dict[str, Any]]) -
         conn.commit()
 
 
+def mark_extrato_reviewed(user_id: int) -> None:
+    """Mark the latest extrato document as reviewed by the user."""
+    with get_cursor() as (conn, cursor):
+        cursor.execute(
+            """
+            UPDATE documentos_financeiros
+            SET revisado = TRUE
+            WHERE id = (
+                SELECT id FROM documentos_financeiros
+                WHERE user_id = %s AND tipo_documento = 'extrato'
+                ORDER BY created_at DESC
+                LIMIT 1
+            )
+            """,
+            (user_id,),
+        )
+        conn.commit()
+
+
 def is_document_processing(user_id: int) -> bool:
     with get_cursor() as (_, cursor):
         cursor.execute(

--- a/app/services/onboarding.py
+++ b/app/services/onboarding.py
@@ -855,6 +855,21 @@ def has_cost_review_candidates(user_id: int) -> bool:
     return bool(fixed_costs or variable_costs)
 
 
+def is_statement_already_reviewed(user_id: int) -> bool:
+    """Return True if the user already confirmed their extrato in STATEMENT_REVIEW_PENDING."""
+    with get_cursor() as (_, cursor):
+        cursor.execute(
+            """
+            SELECT 1 FROM documentos_financeiros
+            WHERE user_id = %s AND tipo_documento = 'extrato'
+              AND revisado = TRUE
+            LIMIT 1
+            """,
+            (user_id,),
+        )
+        return cursor.fetchone() is not None
+
+
 def is_cost_review_completed(user_id: int) -> bool:
     with get_cursor() as (_, cursor):
         if not _column_exists(cursor, "configuracoes_usuario", "custos_onboarding_concluido"):


### PR DESCRIPTION
## Summary

- `db.py`: `ALTER TABLE documentos_financeiros ADD COLUMN IF NOT EXISTS revisado BOOLEAN NOT NULL DEFAULT FALSE`
- `documents.py`: `mark_extrato_reviewed(user_id)` — atualiza o extrato mais recente para `revisado = TRUE`
- `onboarding.py`: `is_statement_already_reviewed(user_id)` — verifica se existe extrato com `revisado = TRUE`
- `main.py` `STATEMENT_REVIEW_PENDING`: chama `mark_extrato_reviewed` quando usuário confirma com SIM
- `main.py` `COST_REVIEW_PENDING`: se `not is_post_cards` (fluxo extrato) e `is_statement_already_reviewed` → avança direto para `CARD_COUNT_PENDING` com "Seus lançamentos já foram organizados"

O fluxo de fatura (`is_post_cards = True`) permanece inalterado e continua passando pelo `COST_REVIEW_PENDING`.

Fixes #93

## Test plan

- [ ] Confirmar extrato em STATEMENT_REVIEW_PENDING com SIM → documento marcado `revisado = TRUE`
- [ ] Após BUDGET_SETUP_PENDING → COST_REVIEW_PENDING não é exibido; avança para cartões
- [ ] Fluxo de fatura (CARD_INVOICE_PENDING → COST_REVIEW_PENDING) continua funcionando normalmente
- [ ] Usuário sem extrato revisado ainda vê COST_REVIEW_PENDING normalmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)