### PR TITLE
fix: require date+amount on same line in _count_raw_transaction_candidates

### DIFF
--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -496,9 +496,21 @@ def _score_page_financial_density(text: str) -> int:
     )
 
 
+_DATE_RE = re.compile(r'\b\d{2}/\d{2}/\d{2,4}\b')
+_AMOUNT_RE = re.compile(r'(?:R\$\s*)?\d{1,3}(?:[.\s]\d{3})*[,]\d{2}|\b\d+[,]\d{2}\b')
+
+
 def _count_raw_transaction_candidates(text: str) -> int:
-    """Count date-like patterns (dd/mm/yy or dd/mm/yyyy) as a proxy for transaction line count."""
-    return len(re.findall(r'\b\d{2}/\d{2}/\d{2,4}\b', text))
+    """Count lines that have both a date (dd/mm/yy|yyyy) and a BRL monetary value.
+
+    Requiring both date and amount on the same line avoids counting header rows,
+    balance/summary lines, and broken pdfplumber wraps that contain only dates.
+    """
+    count = 0
+    for line in text.splitlines():
+        if _DATE_RE.search(line) and _AMOUNT_RE.search(line):
+            count += 1
+    return count
 
 
 def _anonymize_document_text(text: str) -> str:


### PR DESCRIPTION
## Summary

- `_count_raw_transaction_candidates` previously counted **all date patterns** (`dd/mm/yy|yyyy`) in the extracted text
- This caused false positives from: period header lines (`Periodo: 01/04/2026 a 30/04/2026`), saldo/balance rows, footer totals, and pdfplumber-broken lines that carry only a date
- Inflated `raw_count` triggered the GPT completeness retry unnecessarily (extra cost + latency, as seen in production: `raw_candidates=12 gpt_classified=7`)
- New logic counts only lines that contain **both** a date pattern and a BRL monetary value on the same line — a much better proxy for actual transaction row count

## Test plan

- [ ] Upload a multi-page bank statement PDF — verify `doc_completeness_mismatch` no longer fires when GPT returns the correct number of transactions
- [ ] Check logs: `raw_candidates` value should be closer to the actual transaction count, not inflated by header/footer dates
- [ ] Upload a statement with a "Período: dd/mm/yyyy a dd/mm/yyyy" header line — verify it is not counted as a transaction candidate

Fixes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)