### PR TITLE
fix: properly skip COST_REVIEW_PENDING when statement already reviewed

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -418,7 +418,10 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
             return Response(content=build_twiml(resposta), media_type="application/xml")
         budgets = parse_budget_message(mensagem)
         if budgets:
-            next_state = COST_REVIEW_PENDING if has_cost_review_candidates(user_id) and not is_cost_review_completed(user_id) else CARD_COUNT_PENDING
+            _reviewed = is_statement_already_reviewed(user_id)
+            next_state = COST_REVIEW_PENDING if has_cost_review_candidates(user_id) and not is_cost_review_completed(user_id) and not _reviewed else CARD_COUNT_PENDING
+            if _reviewed and next_state == CARD_COUNT_PENDING:
+                logger.info("cost_review_skipped_already_reviewed user_id=%s", user_id)
             save_budgets(user_id, budgets, next_state)
             if next_state == COST_REVIEW_PENDING:
                 fixed_costs, variable_costs = infer_cost_candidates(user_id)
@@ -436,7 +439,10 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
             resposta = budget_edit_prompt()
             return Response(content=build_twiml(resposta), media_type="application/xml")
         if should_skip_budget_onboarding(mensagem):
-            next_state = COST_REVIEW_PENDING if has_cost_review_candidates(user_id) and not is_cost_review_completed(user_id) else CARD_COUNT_PENDING
+            _reviewed = is_statement_already_reviewed(user_id)
+            next_state = COST_REVIEW_PENDING if has_cost_review_candidates(user_id) and not is_cost_review_completed(user_id) and not _reviewed else CARD_COUNT_PENDING
+            if _reviewed and next_state == CARD_COUNT_PENDING:
+                logger.info("cost_review_skipped_already_reviewed user_id=%s", user_id)
             mark_budget_onboarding_completed(user_id, next_state)
             if next_state == COST_REVIEW_PENDING:
                 fixed_costs, variable_costs = infer_cost_candidates(user_id)
@@ -460,6 +466,7 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
             return Response(content=build_twiml(resposta), media_type="application/xml")
 
         if not is_post_cards and is_statement_already_reviewed(user_id):
+            logger.info("cost_review_skipped_already_reviewed user_id=%s", user_id)
             set_onboarding_state(user_id, CARD_COUNT_PENDING)
             resposta = (
                 "Seus lançamentos já foram organizados. Seguindo em frente...\n\n"


### PR DESCRIPTION
## Root cause

The `BUDGET_SETUP_PENDING` handler computed `next_state` using only two conditions:

```python
next_state = COST_REVIEW_PENDING if has_cost_review_candidates(user_id) and not is_cost_review_completed(user_id) else CARD_COUNT_PENDING
```

This ignored `is_statement_already_reviewed()`, so if the user had already confirmed the extrato with **SIM** in `STATEMENT_REVIEW_PENDING`, the handler still sent the cost review prompt when the user skipped or set budgets — re-asking for lançamentos that were already validated.

## Fix

- Added `and not is_statement_already_reviewed(user_id)` to **both** `next_state` conditions in `BUDGET_SETUP_PENDING` (save-budgets path and skip-budgets path)
- Added `logger.info("cost_review_skipped_already_reviewed user_id=X")` at all three guard sites for observability

## Reproduced flow (now fixed)

1. Send extrato → confirm with **SIM** in `STATEMENT_REVIEW_PENDING`
2. Skip budgets with **PULAR** in `BUDGET_SETUP_PENDING`
3. ✅ Navi goes directly to card count prompt — no duplicate cost review

## Test plan

- [ ] Extrato → SIM → PULAR on budgets → verify Navi asks for card count, NOT cost review
- [ ] Extrato → SIM → set budgets (e.g. "Mercado 1200") → verify same
- [ ] Extrato → skip statement review (no SIM) → PULAR on budgets → verify cost review IS still shown
- [ ] Check logs for `cost_review_skipped_already_reviewed` on the skipped path

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)