### PR TITLE
fix: normalize PT-BR accents in GPT-generated categories

### DIFF
--- a/app/services/chat.py
+++ b/app/services/chat.py
@@ -10,7 +10,7 @@ from app.db import get_cursor
 from app.schemas import ParsedTransaction, PendingTransaction
 from app.services.budgets import build_budget_feedback
 from app.services.conversation import save_pending_confirmation, should_request_confirmation
-from app.services.formatting import format_brl
+from app.services.formatting import format_brl, normalize_ptbr_accents
 from app.services.summary import gerar_insight
 
 
@@ -88,7 +88,7 @@ def _extract_transactions_from_ai(text: str) -> list[ParsedTransaction]:
                     'Classifique a mensagem:\n\n'
                     f'"{text}"\n\n'
                     "Retorne uma lista de objetos no formato:\n"
-                    '[{"tipo":"receita ou despesa","categoria":"categoria","subcategoria":"subcategoria especifica ou null","valor":numero}]'
+                    '[{"tipo":"receita ou despesa","categoria":"categoria COM acentuacao PT-BR correta (ex: Alimentação, Educação, Automóvel)","subcategoria":"subcategoria especifica COM acentuacao PT-BR correta ou null","valor":numero}]'
                 ),
             },
         ],
@@ -109,9 +109,11 @@ def _extract_transactions_from_ai(text: str) -> list[ParsedTransaction]:
 
 def _normalize_transaction(text: str, transaction: ParsedTransaction) -> PendingTransaction:
     categoria_regra = classificar_categoria(text)
-    categoria = categoria_regra or _normalizar_texto(transaction.categoria or "outros")
+    categoria_raw = categoria_regra or (transaction.categoria or "outros").strip()
+    categoria = normalize_ptbr_accents(categoria_raw)
     tipo = _normalizar_texto(transaction.tipo or "despesa")
-    subcategoria = transaction.subcategoria.strip() if transaction.subcategoria else None
+    subcategoria_raw = transaction.subcategoria.strip() if transaction.subcategoria else None
+    subcategoria = normalize_ptbr_accents(subcategoria_raw) if subcategoria_raw else None
     return PendingTransaction(tipo=tipo, categoria=categoria, subcategoria=subcategoria, valor=float(transaction.valor))
 
 

--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -15,7 +15,7 @@ from starlette.datastructures import FormData
 
 from app.config import get_settings
 from app.db import get_cursor
-from app.services.formatting import format_brl, format_ptbr_date
+from app.services.formatting import format_brl, format_ptbr_date, normalize_ptbr_accents
 from app.services.logger import get_logger
 from app.services.onboarding import (
     CARD_INVOICE_PENDING,
@@ -333,8 +333,9 @@ def _normalize_statement_rows(rows: Any) -> list[dict[str, Any]]:
 
         tipo_custo_raw = str(row.get("tipo_custo") or "").strip().lower()
         tipo_custo = tipo_custo_raw if tipo_custo_raw in {"fixo", "variavel", "rendimento", "credito"} else "variavel"
-        categoria_sugerida = str(row.get("categoria_sugerida") or "Outros").strip() or "Outros"
-        subcategoria_sugerida = str(row.get("subcategoria_sugerida") or "").strip() or None
+        categoria_sugerida = normalize_ptbr_accents(str(row.get("categoria_sugerida") or "Outros").strip() or "Outros")
+        subcategoria_raw = str(row.get("subcategoria_sugerida") or "").strip()
+        subcategoria_sugerida = normalize_ptbr_accents(subcategoria_raw) if subcategoria_raw else None
 
         normalized_rows.append(
             {
@@ -732,7 +733,7 @@ def _build_document_analysis_system_prompt(income_instructions: str, hinted_type
         '"account_limit":numero ou null,'
         '"pending_charges":numero ou null,'
         '"charges_debit_date":"YYYY-MM-DD" ou null,'
-        '"statement_rows":[{"date":"YYYY-MM-DD ou texto","description":"texto EXATAMENTE como no documento","credit":numero ou null,"debit":numero ou null,"balance":numero ou null,"raw_amount_text":"texto ou null","confidence":"high|medium|low","tipo_custo":"fixo|variavel|rendimento|credito","categoria_sugerida":"nome da categoria ou Outros","subcategoria_sugerida":"subcategoria especifica ou null","confirmado":false}] — INCLUA ABSOLUTAMENTE TODOS os lancamentos sem filtrar,'
+        '"statement_rows":[{"date":"YYYY-MM-DD ou texto","description":"texto EXATAMENTE como no documento","credit":numero ou null,"debit":numero ou null,"balance":numero ou null,"raw_amount_text":"texto ou null","confidence":"high|medium|low","tipo_custo":"fixo|variavel|rendimento|credito","categoria_sugerida":"nome da categoria COM acentuacao PT-BR correta (ex: Alimentação, Educação, Automóvel, Condomínio) ou Outros","subcategoria_sugerida":"subcategoria especifica COM acentuacao PT-BR correta ou null","confirmado":false}] — INCLUA ABSOLUTAMENTE TODOS os lancamentos sem filtrar,'
         '"credit_entries":[{"date":"YYYY-MM-DD ou texto","description":"texto","amount":numero}] (TODOS os creditos: remuneracao de aplicacao, rendimento, estorno, transferencia — mesmo R$0,01),'
         '"debit_entries":[{"date":"YYYY-MM-DD ou texto","description":"texto","amount":numero}] (TODOS os debitos: cartao de debito, PIX enviado, tarifa, compra — mesmo valores pequenos),'
         '"estimated_fixed_expenses":numero ou null,'
@@ -1747,7 +1748,7 @@ def apply_user_adjustments(
                         "Retorne APENAS um array JSON valido, sem markdown, sem texto explicativo, sem objeto envolvente. "
                         "Formato exato: "
                         '[{"indice":N,"acao":"atualizar"|"ignorar",'
-                        '"categoria":"nova categoria ou null","subcategoria":"nova subcategoria ou null",'
+                        '"categoria":"nova categoria COM acentuacao PT-BR correta (ex: Alimentação, Saúde) ou null","subcategoria":"nova subcategoria COM acentuacao PT-BR correta ou null",'
                         '"tipo_custo":"fixo|variavel|rendimento|credito ou null"}]. '
                         "Use 'ignorar' para descartar o lancamento da lista. "
                         "Identifique o lancamento pelo numero (indice) ou por palavras da descricao. "
@@ -1792,9 +1793,10 @@ def apply_user_adjustments(
             applied += 1
             continue
         if adj.get("categoria"):
-            updated[idx]["categoria_sugerida"] = str(adj["categoria"]).strip()
+            updated[idx]["categoria_sugerida"] = normalize_ptbr_accents(str(adj["categoria"]).strip())
         if "subcategoria" in adj and adj["subcategoria"] is not None:
-            updated[idx]["subcategoria_sugerida"] = str(adj["subcategoria"]).strip() or None
+            sub = str(adj["subcategoria"]).strip()
+            updated[idx]["subcategoria_sugerida"] = normalize_ptbr_accents(sub) if sub else None
         if adj.get("tipo_custo") and adj["tipo_custo"] in {"fixo", "variavel", "rendimento", "credito"}:
             updated[idx]["tipo_custo"] = adj["tipo_custo"]
         applied += 1

--- a/app/services/formatting.py
+++ b/app/services/formatting.py
@@ -1,5 +1,61 @@
+import re
 from datetime import datetime
 from typing import Any
+
+# Maps unaccented PT-BR words (lower-case) to their correct accented forms.
+# Keys must be whole words; matching is case-insensitive and preserves original capitalisation.
+_PTBR_ACCENT_MAP: dict[str, str] = {
+    "alimentacao": "alimentação",
+    "educacao": "educação",
+    "comunicacao": "comunicação",
+    "habitacao": "habitação",
+    "manutencao": "manutenção",
+    "variavel": "variável",
+    "variaveis": "variáveis",
+    "automovel": "automóvel",
+    "automoveis": "automóveis",
+    "condominio": "condomínio",
+    "saude": "saúde",
+    "agua": "água",
+    "combustivel": "combustível",
+    "farmacia": "farmácia",
+    "medico": "médico",
+    "medica": "médica",
+    "emergencia": "emergência",
+    "assinatura": "assinatura",
+    "pedagio": "pedágio",
+    "eletricidade": "eletricidade",
+    "telefonia": "telefonia",
+    "academica": "acadêmica",
+    "estacionamento": "estacionamento",
+}
+
+_PTBR_ACCENT_RE = re.compile(
+    r"\b(" + "|".join(re.escape(k) for k in _PTBR_ACCENT_MAP) + r")\b",
+    re.IGNORECASE,
+)
+
+
+def _restore_case(original: str, corrected: str) -> str:
+    """Apply the capitalisation pattern of *original* to *corrected*."""
+    if original.isupper():
+        return corrected.upper()
+    if original[0].isupper():
+        return corrected[0].upper() + corrected[1:]
+    return corrected
+
+
+def normalize_ptbr_accents(text: str) -> str:
+    """Fix common missing PT-BR accents in a string, preserving capitalisation."""
+    if not text:
+        return text
+
+    def _replace(m: re.Match) -> str:  # type: ignore[type-arg]
+        original = m.group(0)
+        corrected = _PTBR_ACCENT_MAP[original.lower()]
+        return _restore_case(original, corrected)
+
+    return _PTBR_ACCENT_RE.sub(_replace, text)
 
 
 def format_brl(value: float | int | None) -> str:


### PR DESCRIPTION
## Summary

- Adds `normalize_ptbr_accents()` to `formatting.py` with a word-boundary regex that corrects 23 common missing PT-BR accents (Alimentação, Educação, Automóvel, etc.) while preserving capitalisation
- Applies normalization in `_normalize_statement_rows` (documents.py) for `categoria_sugerida` and `subcategoria_sugerida`
- Applies normalization in `apply_user_adjustments` (documents.py) for adjusted category/subcategory values
- Applies normalization in `_normalize_transaction` (chat.py) for standalone transactions parsed via GPT
- Updates GPT system prompts in `_build_document_analysis_system_prompt`, `apply_user_adjustments`, and `_extract_transactions_from_ai` to explicitly request PT-BR accented categories

## Test plan

- [ ] Upload an extrato — categories should show "Alimentação", "Saúde", etc. (not "Alimentacao")
- [ ] Send a freeform transaction message — GPT-returned category should be accent-normalized
- [ ] Apply user adjustments (e.g. "muda a categoria para Educação") — normalized category should persist
- [ ] Test capitalisation: "ALIMENTACAO" → "ALIMENTAÇÃO", "Saude" → "Saúde"

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)