### PR TITLE
fix: invoke lean adjustment confirmation message after apply_user_adjustments

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -29,6 +29,7 @@ from app.services.conversation import (
     reject_pending_transaction,
 )
 from app.services.documents import (
+    _build_adjustments_applied_message,
     _build_analysis_message,
     apply_user_adjustments,
     build_invoice_status_message,
@@ -351,10 +352,7 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
             elif updated_rows != existing_rows:
                 analysis["statement_rows"] = updated_rows
                 save_extrato_adjustments(user_id, updated_rows)
-                resposta = (
-                    _build_analysis_message(analysis, "extrato").rstrip()
-                    + "\n\nAjustei conforme solicitado. Confirma agora com SIM?"
-                )
+                resposta = _build_adjustments_applied_message(updated_rows, existing_rows)
             else:
                 resposta = _build_analysis_message(analysis, "extrato")
         else:

--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -1579,6 +1579,46 @@ def _render_statement_rows(rows: list[dict[str, Any]]) -> list[str]:
     return result
 
 
+def _build_adjustments_applied_message(
+    updated_rows: list[dict[str, Any]],
+    original_rows: list[dict[str, Any]],
+) -> str:
+    """Return a lean confirmation after apply_user_adjustments(), listing only what changed."""
+    ignored_count = len(original_rows) - len(updated_rows)
+    original_by_desc = {r.get("description", ""): r for r in original_rows}
+    changes: list[str] = []
+
+    for row in updated_rows:
+        desc = row.get("description", "")
+        orig = original_by_desc.get(desc)
+        if orig is None:
+            continue
+        parts: list[str] = []
+        if orig.get("categoria_sugerida") != row.get("categoria_sugerida"):
+            parts.append(f"categoria: {row.get('categoria_sugerida') or 'Outros'}")
+        if orig.get("subcategoria_sugerida") != row.get("subcategoria_sugerida"):
+            new_sub = row.get("subcategoria_sugerida") or "sem subcategoria"
+            parts.append(f"subcategoria: {new_sub}")
+        if orig.get("tipo_custo") != row.get("tipo_custo"):
+            parts.append(f"tipo: {row.get('tipo_custo', '')}")
+        if parts:
+            changes.append(f"- {desc[:50]}: {', '.join(parts)}")
+
+    if ignored_count > 0:
+        changes.append(f"- {ignored_count} lançamento(s) removido(s) da lista")
+
+    if not changes:
+        return 'Não identifiquei nenhum ajuste para aplicar. Me diga o que quer mudar ou confirme com "SIM".'
+
+    return "\n".join([
+        "Ajustei conforme solicitado:",
+        "",
+        *changes,
+        "",
+        'Me responda "SIM" para confirmar a lista atualizada ou diga o que mais precisa ajustar.',
+    ])
+
+
 def _build_analysis_message(analysis: dict[str, Any], fallback_type: str) -> str:
     document_type = analysis.get("document_type") or fallback_type
     summary = (analysis.get("summary") or "").strip()


### PR DESCRIPTION
## Summary

- Creates `_build_adjustments_applied_message(updated_rows, original_rows)` in `documents.py`
- Compares updated vs original rows by description to identify what changed (categoria, subcategoria, tipo_custo) and how many were ignored/removed
- Returns a short message: "Ajustei conforme solicitado: - [itens modificados]" — no balance, no limit, no full row list
- `STATEMENT_REVIEW_PENDING` handler now calls `_build_adjustments_applied_message()` instead of `_build_analysis_message().rstrip() + "\n\nAjustei..."` 
- Falls back to a neutral "não identifiquei ajuste" message when GPT returned no changes

## Before / After

**Before:** user sends "mercado entra em alimentação" → receives full 1200-char re-analysis with header, balance, all rows, limits

**After:** user receives:
```
Ajustei conforme solicitado:

- Supermercado Lopes: categoria: Alimentação, subcategoria: supermercado

Me responda "SIM" para confirmar a lista atualizada ou diga o que mais precisa ajustar.
```

Fixes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)