### PR TITLE
fix: apply locale-aware cost type formatting in all user-facing messages

### DIFF
--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -500,6 +500,18 @@ def _score_page_financial_density(text: str) -> int:
 _DATE_RE = re.compile(r'\b\d{2}/\d{2}/\d{2,4}\b')
 _AMOUNT_RE = re.compile(r'(?:R\$\s*)?\d{1,3}(?:[.\s]\d{3})*[,]\d{2}|\b\d+[,]\d{2}\b')
 
+_COST_TYPE_DISPLAY: dict[str, str] = {
+    "fixo": "fixo",
+    "variavel": "variável",
+    "rendimento": "rendimento",
+    "credito": "crédito",
+}
+
+
+def _format_cost_type(tipo_custo: str) -> str:
+    """Return a user-facing, accented label for a tipo_custo internal value."""
+    return _COST_TYPE_DISPLAY.get((tipo_custo or "").lower().strip(), tipo_custo)
+
 
 def _count_raw_transaction_candidates(text: str) -> int:
     """Count lines that have both a date (dd/mm/yy|yyyy) and a BRL monetary value.
@@ -1562,7 +1574,7 @@ def _render_statement_rows(rows: list[dict[str, Any]]) -> list[str]:
             valor_str = f"-R${row['debit']:.2f}"
         else:
             valor_str = ""
-        tipo = row.get("tipo_custo") or ""
+        tipo = _format_cost_type(row.get("tipo_custo") or "")
         cat = row.get("categoria_sugerida") or ""
         subcat = row.get("subcategoria_sugerida") or ""
         cat_display = f"{cat}/{subcat}" if cat and subcat else cat
@@ -1600,7 +1612,7 @@ def _build_adjustments_applied_message(
             new_sub = row.get("subcategoria_sugerida") or "sem subcategoria"
             parts.append(f"subcategoria: {new_sub}")
         if orig.get("tipo_custo") != row.get("tipo_custo"):
-            parts.append(f"tipo: {row.get('tipo_custo', '')}")
+            parts.append(f"tipo: {_format_cost_type(row.get('tipo_custo', ''))}")
         if parts:
             changes.append(f"- {desc[:50]}: {', '.join(parts)}")
 


### PR DESCRIPTION
## Summary

- Adds `_format_cost_type(tipo_custo)` with an accent-correct display map:
  - `variavel` → `variável`
  - `credito` → `crédito`
  - `fixo` → `fixo` (unchanged)
  - `rendimento` → `rendimento` (unchanged)
- Applies it in `_render_statement_rows()` — fixes `(variavel | Alimentação/Mercado)` → `(variável | Alimentação/Mercado)` in every statement listing
- Applies it in `_build_adjustments_applied_message()` — type changes in the lean adjustment message also show correct accents
- Internal values (DB storage, GPT prompts, business logic comparisons) keep raw unaccented strings unchanged

## Audit

All `tipo_custo` display paths checked:
- ✅ `_render_statement_rows()` — now uses `_format_cost_type()`
- ✅ `_build_adjustments_applied_message()` — now uses `_format_cost_type()`
- ✅ `cost_review_prompt()` in `onboarding.py` — does NOT display tipo_custo (only descrição + valor + categoria), no change needed
- ✅ `apply_user_adjustments()` rows_summary — sent to GPT, not to user, no change needed

Fixes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)