### PR TITLE
fix: split long invoice messages into multiple WhatsApp messages to avoid truncation

### DIFF
--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -2023,7 +2023,7 @@ def process_stored_document(
         logger.info("doc_processing_done document_id=%d user_id=%d", document_id, user_id)
         if on_complete_numero:
             from app.services.onboarding import set_onboarding_state
-            from app.services.twilio import responder
+            from app.services.twilio import responder_split
             import time as _time
             if on_complete_state:
                 set_onboarding_state(user_id, on_complete_state)
@@ -2037,7 +2037,7 @@ def process_stored_document(
                 if _delay:
                     _time.sleep(_delay)
                 try:
-                    responder(on_complete_numero, proactive_msg)
+                    responder_split(on_complete_numero, proactive_msg)
                     logger.info(
                         "doc_proactive_ok document_id=%d user_id=%d attempt=%d",
                         document_id, user_id, _attempt,

--- a/app/services/twilio.py
+++ b/app/services/twilio.py
@@ -111,6 +111,24 @@ def _split_message(text: str, max_len: int = _WHATSAPP_MAX_CHARS) -> list[str]:
     return parts or [text[:max_len]]
 
 
+def responder_split(numero: str, mensagem: str) -> None:
+    """Send a long message as multiple sequential WhatsApp messages.
+
+    Each part is prefixed with '(N/M)' when there is more than one part.
+    A 0.5 s delay is added between parts to preserve delivery order.
+    """
+    import time as _time
+
+    parts = _split_message(mensagem, max_len=_WHATSAPP_MAX_CHARS - 8)
+    total = len(parts)
+    for i, part in enumerate(parts, 1):
+        body = f"({i}/{total})\n{part}" if total > 1 else part
+        responder(numero, body)
+        if i < total:
+            _time.sleep(0.5)
+    logger.info("msg_split_sent parts=%d total_len=%d", total, len(mensagem))
+
+
 def build_twiml(message: str | list[str]) -> str:
     if isinstance(message, list):
         chunks: list[str] = []


### PR DESCRIPTION
## Summary

- Adds `responder_split(numero, mensagem)` to `twilio.py`
  - Uses existing `_split_message()` to divide the message at natural paragraph/line boundaries
  - Each part prefixed with `(N/M)` when there are multiple parts
  - 0.5s delay between sends to preserve delivery order in WhatsApp
  - Logs `msg_split_sent parts=N total_len=M`
- `process_stored_document()` now calls `responder_split()` instead of `responder()` for the proactive analysis message
- `responder()` itself unchanged — it is still used for short single-message sends elsewhere

## Root cause

`responder()` line 54: `"Body": mensagem[:_WHATSAPP_MAX_CHARS]` — silently truncated long messages. For faturas with 15+ lançamentos the analysis message can easily exceed 2000 chars, causing all rows beyond the cutoff to be lost.

## Test plan

- [ ] Send a fatura that produces >1500 char analysis message — verify multiple WhatsApp messages arrive in sequence
- [ ] Short messages (< 1492 chars) — sent as single message, no prefix, no change in behavior
- [ ] Verify `msg_split_sent parts=N` log appears for multi-part messages

Fixes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)