### PR TITLE
fix: distribute all transactions across split messages, never truncate with 'e mais N'

### DIFF
--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -1601,7 +1601,7 @@ def _render_statement_rows(rows: list[dict[str, Any]]) -> list[str]:
     if not rows:
         return []
     result: list[str] = ["", f"Lançamentos encontrados ({len(rows)} no total):"]
-    for row in rows[:20]:
+    for row in rows:
         date_prefix = f"{row['date']} " if row.get("date") else ""
         if row.get("credit") is not None:
             valor_str = f"+R${row['credit']:.2f}"
@@ -1620,8 +1620,6 @@ def _render_statement_rows(rows: list[dict[str, Any]]) -> list[str]:
         suffix = f" ({meta})" if meta else ""
         val_part = f": {valor_str}" if valor_str else ""
         result.append(f"- {date_prefix}{row['description']}{val_part}{suffix}")
-    if len(rows) > 20:
-        result.append(f"- ...e mais {len(rows) - 20} lançamentos.")
     result.extend([
         "",
         'Me responda "SIM" para confirmar esses lançamentos, ou me diga o que precisa ajustar.',


### PR DESCRIPTION
## Summary

- Removes `rows[:20]` cap in `_render_statement_rows()` — previously limited rendering to first 20 rows
- Removes `"- ...e mais {len(rows) - 20} lançamentos."` line — all rows are now always rendered
- The full row list is built in memory; `responder_split()` in `twilio.py` handles splitting the resulting text into ≤1492-char WhatsApp messages at natural line boundaries

## Root cause

`_render_statement_rows` capped rendering at 20 items. For a 48-row invoice, only 20 rows were rendered + a truncation notice. `responder_split` then split this already-truncated message. The split was working correctly — the truncation happened upstream before the split.

## Before / After

| Scenario | Before | After |
|---|---|---|
| 48-row invoice | Part 2/3: 20 rows + "...e mais 28 lançamentos" | All 48 rows distributed across however many parts needed |
| 5-row invoice | 5 rows (no change) | 5 rows (no change) |

Fixes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)