### PR TITLE
feat: add review flow for credit card invoices

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -41,12 +41,14 @@ from app.services.documents import (
     document_upload_retry_prompt,
     get_incoming_media,
     get_latest_extrato_analysis,
+    get_latest_fatura_analysis,
     has_document_type,
     is_document_processing,
     is_invoice_followup_message,
     is_document_onboarding_completed,
     is_waiting_for_document,
     mark_extrato_reviewed,
+    mark_fatura_reviewed,
     process_stored_document,
     register_received_document,
     save_extrato_adjustments,
@@ -69,6 +71,7 @@ from app.services.onboarding import (
     CARD_COUNT_PENDING,
     COST_REVIEW_PENDING,
     CARD_INVOICE_PENDING,
+    INVOICE_REVIEW_PENDING,
     CARD_NAMES_PENDING,
     DOCUMENT_ONBOARDING_PENDING,
     advance_card_progress,
@@ -357,6 +360,50 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
                 resposta = _build_analysis_message(analysis, "extrato")
         else:
             resposta = _build_analysis_message(analysis, "extrato")
+        return Response(content=build_twiml(resposta), media_type="application/xml")
+
+    if onboarding_state == INVOICE_REVIEW_PENDING:
+        if is_document_processing(user_id):
+            resposta = "Ainda estou analisando sua fatura, aguarde um momento..."
+            return Response(content=build_twiml(resposta), media_type="application/xml")
+
+        if is_confirmation_yes(msg_lower):
+            mark_fatura_reviewed(user_id)
+            _reviewed = is_statement_already_reviewed(user_id)
+            next_state = (
+                COST_REVIEW_PENDING
+                if has_cost_review_candidates(user_id) and not is_cost_review_completed(user_id) and not _reviewed
+                else CARD_COUNT_PENDING
+            )
+            set_onboarding_state(user_id, next_state)
+            resposta = "Ótimo! Lançamentos da fatura confirmados."
+            return Response(content=build_twiml(resposta), media_type="application/xml")
+
+        analysis = get_latest_fatura_analysis(user_id)
+        if not analysis:
+            _reviewed = is_statement_already_reviewed(user_id)
+            next_state = (
+                COST_REVIEW_PENDING
+                if has_cost_review_candidates(user_id) and not is_cost_review_completed(user_id) and not _reviewed
+                else CARD_COUNT_PENDING
+            )
+            set_onboarding_state(user_id, next_state)
+            resposta = "Não consegui extrair os lançamentos da fatura."
+            return Response(content=build_twiml(resposta), media_type="application/xml")
+
+        existing_rows = analysis.get("statement_rows") or []
+        if existing_rows and mensagem:
+            updated_rows, adj_error = apply_user_adjustments(mensagem, existing_rows, user_id)
+            if adj_error:
+                resposta = adj_error
+            elif updated_rows != existing_rows:
+                analysis["statement_rows"] = updated_rows
+                save_extrato_adjustments(user_id, updated_rows)
+                resposta = _build_adjustments_applied_message(updated_rows, existing_rows)
+            else:
+                resposta = _build_analysis_message(analysis, "fatura_cartao")
+        else:
+            resposta = _build_analysis_message(analysis, "fatura_cartao")
         return Response(content=build_twiml(resposta), media_type="application/xml")
 
     if onboarding_state == BUDGET_SETUP_PENDING or not is_budget_onboarding_completed(user_id):
@@ -669,15 +716,15 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
                     )
                 else:
                     card_name_display = str(current_card["nome_cartao"])
-                    set_onboarding_state(user_id, COST_REVIEW_PENDING)
                     _register_document_upload(
                         "fatura_cartao",
                         on_complete_numero=numero,
+                        on_complete_state=INVOICE_REVIEW_PENDING,
                     )
                     resposta = (
                         f"Recebi sua fatura do {card_name_display}. "
                         "Estou analisando os lançamentos agora, isso leva alguns instantes...\n\n"
-                        "Assim que terminar, te mando o que identifiquei."
+                        "Assim que terminar, te mando a lista completa para você revisar."
                     )
                 return Response(content=build_twiml(resposta), media_type="application/xml")
 

--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -2010,6 +2010,45 @@ def get_latest_extrato_analysis(user_id: int) -> dict[str, Any] | None:
         return None
 
 
+def get_latest_fatura_analysis(user_id: int) -> dict[str, Any] | None:
+    with get_cursor() as (_, cursor):
+        cursor.execute(
+            """
+            SELECT extracted_json FROM documentos_financeiros
+            WHERE user_id = %s AND tipo_documento = 'fatura_cartao'
+              AND extracted_json IS NOT NULL
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            (user_id,),
+        )
+        row = cursor.fetchone()
+    if not row:
+        return None
+    try:
+        return json.loads(row[0])
+    except Exception:
+        return None
+
+
+def mark_fatura_reviewed(user_id: int) -> None:
+    with get_cursor() as (conn, cursor):
+        cursor.execute(
+            """
+            UPDATE documentos_financeiros
+            SET revisado = TRUE
+            WHERE id = (
+                SELECT id FROM documentos_financeiros
+                WHERE user_id = %s AND tipo_documento = 'fatura_cartao'
+                ORDER BY created_at DESC
+                LIMIT 1
+            )
+            """,
+            (user_id,),
+        )
+        conn.commit()
+
+
 def process_stored_document(
     document_id: int,
     user_id: int,

--- a/app/services/onboarding.py
+++ b/app/services/onboarding.py
@@ -18,6 +18,7 @@ CARD_COUNT_PENDING = "card_count_pending"
 CARD_NAMES_PENDING = "card_names_pending"
 CARD_DETAILS_PENDING = "card_details_pending"
 CARD_INVOICE_PENDING = "card_invoice_pending"
+INVOICE_REVIEW_PENDING = "invoice_review_pending"
 DOCUMENT_ONBOARDING_PENDING = "document_onboarding_pending"
 ONBOARDING_COMPLETE = "onboarding_complete"
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -122,6 +122,11 @@ CARD_INVOICE_PENDING
   Aceita: mídia; "pular" avança para o próximo cartão.
       │
       ▼
+INVOICE_REVIEW_PENDING
+  Após processar a última fatura, exibe os lançamentos extraídos e aguarda confirmação.
+  Aceita: "sim"/"ok" confirma e avança; qualquer outro texto é tratado como ajuste (igual ao STATEMENT_REVIEW_PENDING).
+      │
+      ▼
 DOCUMENT_ONBOARDING_PENDING
   Convida para enviar extrato ou fatura caso ainda não tenha sido enviado.
   Aceita: mídia, "sim", "pular".


### PR DESCRIPTION
## Summary
- Adds `INVOICE_REVIEW_PENDING` state after `CARD_INVOICE_PENDING` so users can review extracted invoice rows before advancing
- Mirrors the existing `STATEMENT_REVIEW_PENDING` flow: confirmation advances to next state, any other text is treated as an adjustment
- Adds `get_latest_fatura_analysis()` and `mark_fatura_reviewed()` to `documents.py`
- Documents new state in `docs/SPEC.md`

Fixes #118

## Test plan
- [ ] After sending the last card invoice, bot displays extracted rows and asks for confirmation
- [ ] Sending "sim" marks the invoice as reviewed and advances to next state
- [ ] Sending an adjustment (e.g. "remova a linha X") applies the adjustment and shows the updated rows
- [ ] If no analysis is available, flow advances to next state without blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)