### PR TITLE
chore: remove explicit part indicators from split messages

### DIFF
--- a/app/services/twilio.py
+++ b/app/services/twilio.py
@@ -114,16 +114,14 @@ def _split_message(text: str, max_len: int = _WHATSAPP_MAX_CHARS) -> list[str]:
 def responder_split(numero: str, mensagem: str) -> None:
     """Send a long message as multiple sequential WhatsApp messages.
 
-    Each part is prefixed with '(N/M)' when there is more than one part.
     A 0.5 s delay is added between parts to preserve delivery order.
     """
     import time as _time
 
-    parts = _split_message(mensagem, max_len=_WHATSAPP_MAX_CHARS - 8)
+    parts = _split_message(mensagem, max_len=_WHATSAPP_MAX_CHARS)
     total = len(parts)
     for i, part in enumerate(parts, 1):
-        body = f"({i}/{total})\n{part}" if total > 1 else part
-        responder(numero, body)
+        responder(numero, part)
         if i < total:
             _time.sleep(0.5)
     logger.info("msg_split_sent parts=%d total_len=%d", total, len(mensagem))


### PR DESCRIPTION
## Summary
- Removes `(N/M)` prefix from split WhatsApp messages — cleaner UX, less noise for users
- Also restores `max_len` to full `_WHATSAPP_MAX_CHARS` (no longer needs to reserve 8 chars for the indicator)

Fixes #116

## Test plan
- [ ] Long messages still arrive as multiple parts in correct order
- [ ] No `(1/3)` style prefix appears in any message

🤖 Generated with [Claude Code](https://claude.com/claude-code)