### PR TITLE
fix: header appears only once in first split message

### DIFF
--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -1649,11 +1649,12 @@ def _render_statement_rows(rows: list[dict[str, Any]], user_locale: str = "pt-BR
     """Render statement_rows as display lines, including header and call-to-action.
 
     Returns an empty list when rows is empty so callers can extend unconditionally.
-    Prepends a blank separator line when non-empty.
+    The header is NOT preceded by a blank line so it stays in the same paragraph as
+    the invoice summary — ensuring it appears in the first split message, not alone.
     """
     if not rows:
         return []
-    result: list[str] = ["", f"Lançamentos encontrados ({len(rows)} no total):"]
+    result: list[str] = [f"Lançamentos encontrados ({len(rows)} no total):"]
     low_confidence_count = 0
     for row in rows:
         raw_date = row.get("date")


### PR DESCRIPTION
## Summary
- Remove the leading `""` from `_render_statement_rows` that was creating a `\n\n` paragraph break before `"Lançamentos encontrados"`
- Without the blank line, the header stays in the same paragraph as the invoice summary — `_split_message` always places it in message 1 together with the summary, never alone and never repeated

**Before:** summary → `\n\n` → header (alone in message 1 when summary fills the window) → transactions in message 2
**After:** summary + header + first transactions all in message 1 → remaining transactions → footer

## Test plan
- [ ] Send a fatura with 15+ transactions; confirm message 1 contains summary + "Lançamentos encontrados" + first transactions
- [ ] Confirm "Me responda SIM" appears only in the last message
- [ ] Confirm "Lançamentos encontrados" does NOT appear in message 2+

Fixes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)