### PR TITLE
fix: expand non-transactional filter based on generic pattern

### DIFF
--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -288,6 +288,9 @@ _NON_TRANSACTION_PREFIXES = (
     "saldo final",
     "saldo em ",
     "saldo periodo",
+    # Generic summary-row patterns: "Total Nacional", "Total de débitos", etc.
+    "total ",
+    "subtotal ",
 )
 
 
@@ -560,6 +563,8 @@ _HEADER_LINE_RE = re.compile(
     r'|provis[ãa]o'                      # "Provisão de encargos"
     r'|encargos'                         # "encargos a debitar"
     r'|limite\s+da?\s+conta'             # "Limite da conta"
+    r'|\btotal\b'                        # "Total Nacional", "Total da fatura", etc.
+    r'|\bsubtotal\b'                     # "Subtotal" summary rows
     r')',
     re.IGNORECASE,
 )
@@ -578,7 +583,7 @@ def _format_cost_type(tipo_custo: str) -> str:
 
 
 def _count_raw_transaction_candidates(text: str) -> int:
-    """Count lines that have both a date (dd/mm/yy|yyyy) and a BRL monetary value,
+    """Count lines that have both a date (dd/mm/yy|yyyy) and a monetary value,
     excluding known header/summary patterns (period delimiters, balance lines, etc.).
 
     Two-date lines (e.g. "Período: 01/04 a 30/04") are also excluded because a
@@ -591,7 +596,8 @@ def _count_raw_transaction_candidates(text: str) -> int:
         if len(_DATE_RE.findall(line)) > 1:
             continue  # period header — two dates, not a transaction
         if _HEADER_LINE_RE.search(line):
-            continue  # balance/summary/fee line
+            continue  # balance/summary/fee/total line
+        logger.debug("raw_candidate line=%.200s", line.strip())
         count += 1
     return count
 


### PR DESCRIPTION
## Summary
Root cause: lines containing "total" (e.g. "Total Nacional R\$1.542,34 15/04") matched `_DATE_RE` + `_AMOUNT_RE` and were counted as raw transaction candidates, but GPT correctly excluded them — producing a false `raw_candidates=9 gpt_classified=7` mismatch that triggered an unnecessary retry.

Changes:
- `_HEADER_LINE_RE`: add `\btotal\b` and `\bsubtotal\b` — any line with these words + date + amount is a summary row, not a transaction
- `_NON_TRANSACTION_PREFIXES`: add `"total "` and `"subtotal "` — if GPT returns a row with such a description, `_normalize_statement_rows` now filters it (`filtered >= 2`)  
- `_count_raw_transaction_candidates`: add `logger.debug` line for every counted candidate to support future diagnosis

All patterns are generic — no bank names, currencies, or country-specific text.

## Test plan
- [ ] Reprocess the extrato that produced `raw_candidates=9 filtered=0` — confirm `raw_candidates=7 filtered=0` (or `filtered=2` if GPT includes the total rows)
- [ ] Confirm no retry triggered for a normal 7-transaction document
- [ ] Run with DEBUG log level; confirm each counted candidate line appears in logs

Fixes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)