### PR TITLE
fix: use pdfplumber extract_words with Y-grouping to preserve full monetary values in multi-column invoices

### DIFF
--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -659,18 +659,48 @@ def _ocr_image_bytes(image_bytes: bytes) -> str:
         return ""
 
 
+def _extract_words_with_y_grouping(page: Any, y_tolerance: float = 3.0) -> str:
+    """
+    Reconstruct page text by grouping words with similar Y into lines.
+
+    extract_text() linearizes the page by reading order and in multi-column
+    layouts (e.g. credit card invoices with DATE | DESC | USD | BRL columns)
+    can split a value mid-number — "R$ 3.542,34" becomes "R$ 3." on one line
+    and "542,34" on another. extract_words() preserves x0/top per word so we
+    can group by Y (±y_tolerance) and order by X, keeping values intact.
+
+    Bank-agnostic: no assumption about column count or positions.
+    """
+    try:
+        words = page.extract_words()
+    except Exception:
+        return ""
+    if not words:
+        return ""
+    words_sorted = sorted(words, key=lambda w: (w["top"], w["x0"]))
+    lines: list[list[dict]] = []
+    for w in words_sorted:
+        if lines and abs(w["top"] - lines[-1][0]["top"]) <= y_tolerance:
+            lines[-1].append(w)
+        else:
+            lines.append([w])
+    return "\n".join(
+        " ".join(w["text"] for w in sorted(line, key=lambda x: x["x0"]))
+        for line in lines
+    ).strip()
+
+
 def _extract_pdfplumber_page(page: Any) -> str:
     """
-    Extract text from a pdfplumber page preserving table row structure.
+    Extract text from a pdfplumber page preserving spatial structure.
 
-    Tries line-based then text-based table detection so that multi-column
-    transaction tables (Date | Description | Debit | Credit | Balance) are
-    returned as pipe-separated rows instead of spatially-scrambled text.
-
-    Falls back to extract_text(layout=True) which respects the spatial layout
-    of columns, preventing numeric fragmentation in multi-currency invoices
-    (e.g. "US$ 0,00  R$ 227,48" could become "22" + "7,48" with naive extraction).
-    Last resort is plain extract_text() for pages where layout mode fails.
+    Strategy chain:
+      1. Table extraction (lines → text) — if the page has ruled or
+         text-aligned tables, return pipe-separated rows.
+      2. Word extraction with Y-grouping — reconstructs lines from
+         positioned words, keeping multi-column values whole.
+      3. Plain extract_text() — last resort; may fragment values but
+         guarantees a non-empty result for unusual layouts.
     """
     for table_settings in (
         {"vertical_strategy": "lines", "horizontal_strategy": "lines"},
@@ -691,17 +721,15 @@ def _extract_pdfplumber_page(page: Any) -> str:
                 if sum(1 for c in cells if c) >= 2:
                     rows.append(" | ".join(cells))
         if len(rows) >= 2:
+            logger.debug("pdf_extraction_strategy strategy=tables")
             return "\n".join(rows)
 
-    # layout=True preserves column alignment — prevents values from multi-column
-    # rows (e.g. USD and BRL columns) being re-ordered or split across lines.
-    try:
-        text = page.extract_text(layout=True) or ""
-        if text.strip():
-            return re.sub(r"\s+\n", "\n", text).strip()
-    except Exception:
-        pass
+    words_text = _extract_words_with_y_grouping(page)
+    if words_text:
+        logger.debug("pdf_extraction_strategy strategy=words")
+        return words_text
 
+    logger.debug("pdf_extraction_strategy strategy=text")
     text = page.extract_text() or ""
     return re.sub(r"\s+\n", "\n", text).strip()
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -595,6 +595,16 @@ O Navi atende múltiplas instituições financeiras (bancos brasileiros e futura
 Extratos e faturas podem ter várias colunas numéricas por transação (valor em moeda estrangeira, saldo, conversão, código de documento). O prompt instrui o GPT genericamente:
 > "Para cada lançamento, identifique qual é o VALOR EFETIVO debitado ou creditado na conta do usuário. Coloque esse valor em `credit` ou `debit` e o código ISO 4217 da moeda no campo `moeda`. Se não tiver certeza, retorne `confidence: 'low'`."
 
+### Estratégia de extração de texto do PDF
+
+Para que o GPT receba valores íntegros, a camada de extração preserva a estrutura espacial do PDF antes de enviar o texto ao prompt. A função `_extract_pdfplumber_page` aplica, em ordem:
+
+1. **Extração por tabela** — `extract_tables()` com `vertical_strategy=lines` e, se não houver linhas, `vertical_strategy=text`. Retorna linhas separadas por ` | ` quando detecta ≥ 2 linhas úteis.
+2. **Agrupamento por Y a partir de `extract_words()`** — cada palavra vem com `x0`/`top`. Palavras com `top` dentro de ±3 px pertencem à mesma linha visual; dentro da linha ordena-se por `x0`. Mantém valores multicoluna inteiros (ex.: `US$ 0,00 R$ 3.542,34`), sem qualquer suposição sobre quantidade ou posição de colunas — funciona para qualquer banco/emissor.
+3. **`extract_text()` cru** — último recurso, usado apenas quando as estratégias anteriores não retornam texto. Pode linearizar e fragmentar valores, mas garante saída para layouts atípicos.
+
+A estratégia escolhida é logada como `pdf_extraction_strategy strategy=tables|words|text`. Essa escolha é agnóstica a layout e não substitui as regras acima — o GPT continua sendo o único responsável por interpretar o significado financeiro do texto extraído.
+
 ### Correção de bugs de valor
 
 Se um valor incorreto for extraído:


### PR DESCRIPTION
## Summary
- Adds `_extract_words_with_y_grouping()`: reconstructs page text from `extract_words()` by grouping words with similar `top` (±3 px) and ordering within each line by `x0`. Keeps multi-column values whole.
- Reorders `_extract_pdfplumber_page` strategy chain to: **tables → words+Y-grouping → plain `extract_text()`**. Removes `extract_text(layout=True)` — the word-based path supersedes it and is more robust for fragmented layouts.
- Emits `pdf_extraction_strategy strategy=tables|words|text` debug log so we can see which path each page took.
- Updates `docs/SPEC.md` with the new strategy chain under "Princípios de Extração de Valores Monetários".

## Root cause
Production data showed `raw_amount_text='R$ 3.'` and `raw_amount_text='R$ 24'` in `documentos_financeiros.extracted_json` — values were already cut before reaching GPT. In multi-column credit card invoices (`DATE | DESC | USD | BRL`), `extract_text()` linearizes by reading order and can split a value mid-number. `extract_words()` keeps each word positioned, so grouping by Y rebuilds each visual row intact.

## Bank-agnostic
No hardcoded column count, positions, currency names, or monetary regex. Works for any layout with any number of columns.

Fixes #142

## Test plan
- [ ] Resend the multi-currency invoice via WhatsApp
- [ ] Query `SELECT SUBSTRING(extracted_json FROM 1 FOR 1000) FROM documentos_financeiros WHERE tipo_documento='fatura_cartao' ORDER BY created_at DESC LIMIT 1;` — `raw_amount_text` must contain full values for both "Pgto Boleto" entries (not `R$ 3.` / `R$ 24`)
- [ ] `debit` fields must hold correct decimal values (3542.34, 242.89)
- [ ] Resend a bank statement — all transactions still extracted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)