### PR TITLE
fix: prevent pdfplumber from fragmenting monetary values in multi-column PDFs

### DIFF
--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -659,7 +659,7 @@ def _ocr_image_bytes(image_bytes: bytes) -> str:
         return ""
 
 
-def _extract_words_with_y_grouping(page: Any, y_tolerance: float = 3.0) -> str:
+def _extract_words_with_y_grouping(page: Any, y_tolerance: float = 5.0) -> str:
     """
     Reconstruct page text by grouping words with similar Y into lines.
 
@@ -672,7 +672,7 @@ def _extract_words_with_y_grouping(page: Any, y_tolerance: float = 3.0) -> str:
     Bank-agnostic: no assumption about column count or positions.
     """
     try:
-        words = page.extract_words()
+        words = page.extract_words(x_tolerance=0, y_tolerance=0)
     except Exception:
         return ""
     if not words:
@@ -694,36 +694,15 @@ def _extract_pdfplumber_page(page: Any) -> str:
     """
     Extract text from a pdfplumber page preserving spatial structure.
 
-    Strategy chain:
-      1. Table extraction (lines → text) — if the page has ruled or
-         text-aligned tables, return pipe-separated rows.
-      2. Word extraction with Y-grouping — reconstructs lines from
-         positioned words, keeping multi-column values whole.
-      3. Plain extract_text() — last resort; may fragment values but
-         guarantees a non-empty result for unusual layouts.
-    """
-    for table_settings in (
-        {"vertical_strategy": "lines", "horizontal_strategy": "lines"},
-        {"vertical_strategy": "text", "horizontal_strategy": "text"},
-    ):
-        try:
-            tables = page.extract_tables(table_settings)
-        except Exception:
-            tables = []
-        if not tables:
-            continue
-        rows: list[str] = []
-        for table in tables:
-            for row in table:
-                if not row:
-                    continue
-                cells = [str(cell or "").strip().replace("\n", " ") for cell in row]
-                if sum(1 for c in cells if c) >= 2:
-                    rows.append(" | ".join(cells))
-        if len(rows) >= 2:
-            logger.debug("pdf_extraction_strategy strategy=tables")
-            return "\n".join(rows)
+    Strategy:
+      1. Word extraction with Y-grouping — reconstructs lines from
+         positioned words by grouping words with similar Y-coordinates,
+         keeping multi-column monetary values whole (prevents fragmenting
+         "R$ 3.542,34" into "R$ 3." and "542,34").
+      2. Plain extract_text() — fallback for unusual layouts.
 
+    Table extraction was removed as it fragments monetary values across cells.
+    """
     words_text = _extract_words_with_y_grouping(page)
     if words_text:
         logger.debug("pdf_extraction_strategy strategy=words")


### PR DESCRIPTION
## Summary
- Removes table extraction strategy that fragments monetary values across cells
- Uses word-based Y-grouping exclusively to preserve complete values like "R$ 3.542,34"
- Increases Y-tolerance to handle vertical misalignments between characters

## Problem
pdfplumber's `extract_tables()` was fragmenting monetary values in multi-column layouts, causing "R$ 3.542,34" to be extracted as "R$.3". This resulted in incorrect `raw_amount_text` values being sent to GPT.

## Changes
- **Removed** table extraction from `_extract_pdfplumber_page()` 
- **Made** word-based Y-grouping the primary extraction strategy
- **Increased** Y-tolerance from 3.0 to 5.0 pixels
- **Added** `x_tolerance=0, y_tolerance=0` to prevent premature word merging

## Test plan
- [ ] Upload a multi-column bank statement PDF with monetary values
- [ ] Verify `raw_amount_text` contains complete values (e.g., "R$ 3.542,34" not "R$.3")
- [ ] Check that credit/debit amounts are correctly parsed
- [ ] Confirm no regression in single-column PDFs

Fixes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)