### PR TITLE
fix: use median Y-coordinate and higher tolerances to prevent PDF value fragmentation

### DIFF
--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -672,7 +672,9 @@ def _extract_words_with_y_grouping(page: Any, y_tolerance: float = 5.0) -> str:
     Bank-agnostic: no assumption about column count or positions.
     """
     try:
-        words = page.extract_words(x_tolerance=0, y_tolerance=0)
+        # Use reasonable tolerances to prevent character-level fragmentation
+        # x_tolerance=3, y_tolerance=3 keeps monetary values like "R$ 3.542,34" together
+        words = page.extract_words(x_tolerance=3, y_tolerance=3)
     except Exception:
         return ""
     if not words:
@@ -680,8 +682,14 @@ def _extract_words_with_y_grouping(page: Any, y_tolerance: float = 5.0) -> str:
     words_sorted = sorted(words, key=lambda w: (w["top"], w["x0"]))
     lines: list[list[dict]] = []
     for w in words_sorted:
-        if lines and abs(w["top"] - lines[-1][0]["top"]) <= y_tolerance:
-            lines[-1].append(w)
+        if lines:
+            # Compare against median Y of current line to handle gradual Y drift
+            line_y_coords = [word["top"] for word in lines[-1]]
+            median_y = sorted(line_y_coords)[len(line_y_coords) // 2]
+            if abs(w["top"] - median_y) <= y_tolerance:
+                lines[-1].append(w)
+            else:
+                lines.append([w])
         else:
             lines.append([w])
     return "\n".join(


### PR DESCRIPTION
## Summary
- Fixed PDF extraction fragmenting monetary values in multi-column layouts
- Changed extract_words() tolerances from (0,0) to (3,3) to prevent character-level fragmentation
- Now compares against median Y of line instead of first word to handle Y-coordinate drift

## Root Cause (confirmed by production data)
- `raw_amount_text='R$ 3.'` → actual value `R$ 3,542.34`
- `raw_amount_text='R$ 24'` → actual value `R$ 242.89`
- pdfplumber was fragmenting values before GPT processing

## Technical Changes
1. **extract_words() tolerances**: `x_tolerance=0, y_tolerance=0` → `x_tolerance=3, y_tolerance=3`
   - Prevents splitting "R$ 3.542,34" into separate character chunks
   
2. **Y-grouping logic**: Compare against first word → Compare against median Y
   - Handles gradual Y-coordinate drift across long lines
   - Words with slightly varying Y positions now group correctly into same line

## Test Plan
- [ ] Test with multi-column credit card invoices
- [ ] Verify monetary values are extracted completely
- [ ] Check that GPT receives intact values (no "R$ 3." fragments)
- [ ] Validate with bank statements that have tight column layouts

Fixes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)