### PR TITLE
fix: correct PT-BR accentuation in GPT adjustments example

### DIFF
--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -1932,7 +1932,7 @@ _ADJUSTMENTS_ERROR_MSG = (
 )
 
 _ADJUSTMENTS_EXAMPLE = (
-    'Exemplo de saida esperada: [{"indice":2,"acao":"atualizar","categoria":"Alimentacao","subcategoria":"supermercado","tipo_custo":"variavel"},'
+    'Exemplo de saida esperada: [{"indice":2,"acao":"atualizar","categoria":"Alimentação","subcategoria":"Supermercado","tipo_custo":"variavel"},'
     '{"indice":5,"acao":"ignorar","categoria":null,"subcategoria":null,"tipo_custo":null}]'
 )
 


### PR DESCRIPTION
## Summary
Fix unaccented category names returned by GPT after user sends adjustments.

## Root Cause

`_ADJUSTMENTS_EXAMPLE` (line 1934) provided this example to GPT:
```json
{"categoria":"Alimentacao","subcategoria":"supermercado"}
```

GPT follows few-shot examples more strongly than system instructions. Even though the prompt says *"retorne com acentuação CORRETAS"*, the example overrides that — GPT learned to return `"Alimentacao"` instead of `"Alimentação"`.

## Fix

Updated the example to use correct PT-BR spellings:
```json
{"categoria":"Alimentação","subcategoria":"Supermercado"}
```

## Impact
- Category and subcategory names returned after user adjustments now use proper PT-BR accents
- No logic changes — single constant update

Fixes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)