### PR TITLE
fix: persist invoice adjustments to correct document and confirm unrecognized input

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -354,10 +354,10 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
                 resposta = adj_error
             elif updated_rows != existing_rows:
                 analysis["statement_rows"] = updated_rows
-                save_extrato_adjustments(user_id, updated_rows)
+                save_extrato_adjustments(user_id, updated_rows, tipo_documento="extrato")
                 resposta = _build_adjustments_applied_message(updated_rows, existing_rows)
             else:
-                resposta = _build_analysis_message(analysis, "extrato")
+                resposta = _build_adjustments_applied_message(existing_rows, existing_rows)
         else:
             resposta = _build_analysis_message(analysis, "extrato")
         return Response(content=build_twiml(resposta), media_type="application/xml")
@@ -398,10 +398,10 @@ async def webhook(request: Request, background_tasks: BackgroundTasks) -> Respon
                 resposta = adj_error
             elif updated_rows != existing_rows:
                 analysis["statement_rows"] = updated_rows
-                save_extrato_adjustments(user_id, updated_rows)
+                save_extrato_adjustments(user_id, updated_rows, tipo_documento="fatura_cartao")
                 resposta = _build_adjustments_applied_message(updated_rows, existing_rows)
             else:
-                resposta = _build_analysis_message(analysis, "fatura_cartao")
+                resposta = _build_adjustments_applied_message(existing_rows, existing_rows)
         else:
             resposta = _build_analysis_message(analysis, "fatura_cartao")
         return Response(content=build_twiml(resposta), media_type="application/xml")

--- a/app/services/documents.py
+++ b/app/services/documents.py
@@ -2034,18 +2034,18 @@ def apply_user_adjustments(
     return result, None
 
 
-def save_extrato_adjustments(user_id: int, updated_rows: list[dict[str, Any]]) -> None:
-    """Persist adjusted statement_rows back to the latest extrato extracted_json."""
+def save_extrato_adjustments(user_id: int, updated_rows: list[dict[str, Any]], tipo_documento: str = "extrato") -> None:
+    """Persist adjusted statement_rows back to the latest document of given tipo_documento."""
     with get_cursor() as (_, cursor):
         cursor.execute(
             """
             SELECT id, extracted_json FROM documentos_financeiros
-            WHERE user_id = %s AND tipo_documento = 'extrato'
+            WHERE user_id = %s AND tipo_documento = %s
               AND extracted_json IS NOT NULL
             ORDER BY created_at DESC
             LIMIT 1
             """,
-            (user_id,),
+            (user_id, tipo_documento),
         )
         row = cursor.fetchone()
     if not row:


### PR DESCRIPTION
## Summary
- Fix invoice (fatura_cartao) adjustments being silently discarded or saved to the wrong document
- Fix missing feedback when the user's adjustment message is not understood

## Bugs Fixed

### 1. Adjustments saved to wrong document (`save_extrato_adjustments`)

`save_extrato_adjustments()` always queried `tipo_documento = 'extrato'`:
```sql
WHERE user_id = %s AND tipo_documento = 'extrato'
```

When called from `INVOICE_REVIEW_PENDING`, two bad outcomes:
- **No extrato exists** → `row = None` → early return → adjustments silently discarded
- **Extrato exists** → adjustments saved to the extrato, not the fatura

**Fix:** Added `tipo_documento` parameter with `"extrato"` default. Both review handlers now pass the correct type explicitly.

### 2. No feedback when adjustment is not understood

When GPT returned no adjustments (`[]`), `updated_rows is existing_rows` (same reference), so `updated_rows != existing_rows` was `False`. The `else` branch just re-displayed the full transaction listing — the user saw no indication that their correction wasn't applied.

**Fix:** `else` branch now calls `_build_adjustments_applied_message(existing_rows, existing_rows)`, which detects no changes and returns:
> *"Não identifiquei nenhum ajuste para aplicar. Me diga o que quer mudar ou confirme com "SIM"."*

## Changes

| File | Change |
|------|--------|
| `app/services/documents.py` | `save_extrato_adjustments()` accepts `tipo_documento` param |
| `app/main.py` | `STATEMENT_REVIEW_PENDING`: pass `tipo_documento="extrato"` explicitly |
| `app/main.py` | `INVOICE_REVIEW_PENDING`: pass `tipo_documento="fatura_cartao"` |
| `app/main.py` | Both handlers: `else` → `_build_adjustments_applied_message` instead of re-display |

Fixes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)