### PR TITLE
fix(ci): allow port 8000 through Ubuntu ufw on deploy (#160)

### DIFF
--- a/.github/scripts/deploy_template.sh
+++ b/.github/scripts/deploy_template.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 echo "=== Navi Deploy Start ==="
 
+# Ensure OS firewall (ufw) allows port 8000
+ufw allow 8000/tcp 2>/dev/null || true
+
 APP_DIR=/home/__USER__/navimvp
 mkdir -p "$APP_DIR/db"
 cd "$APP_DIR"


### PR DESCRIPTION
## What & Why
Closes #160 (secondary blocker)

After PR #161 opened the Azure NSG for port 8000, \`curl\` returned **Connection refused** instead of timeout — meaning packets reach the VM but the Ubuntu OS firewall (ufw) blocks them at the TCP layer. This adds \`ufw allow 8000/tcp\` early in \`deploy_template.sh\`, which runs on the VM via \`az vm run-command invoke\`.

## Changes
- \`.github/scripts/deploy_template.sh\` — add \`ufw allow 8000/tcp\` before docker operations

## Test coverage
- [x] Infra-only change — no application code modified
- [x] Idempotent: ufw safely handles duplicate allow rules
- [ ] Post-deploy validation: \`curl http://20.195.185.242:8000/health\` must return HTTP 200

## Compliance
- [x] No PII logged
- [x] No secrets in code
- [x] LGPD: not applicable
- [x] Security: only port 8000 opened; ufw status on 5432 unchanged

## How to test
1. Merge and wait for pipeline to complete
2. Run: \`curl -s http://20.195.185.242:8000/health\`
3. Expect: HTTP 200 with \`{"status":"ok",...}\`