### PR TITLE
chore(ci): add post-deploy container health verification (#160)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -97,3 +97,11 @@ jobs:
             --name navimvp-hom-vm \
             --command-id RunShellScript \
             --scripts @/tmp/deploy.sh
+
+      - name: Verify container health on VM
+        run: |
+          az vm run-command invoke \
+            --resource-group navimvp-hom-rg \
+            --name navimvp-hom-vm \
+            --command-id RunShellScript \
+            --scripts "sleep 5 && docker ps && echo '--- app logs ---' && docker logs navimvp-app-1 --tail 30 && curl -sf http://localhost:8000/health && echo 'HEALTH OK' || echo 'HEALTH FAILED'"


### PR DESCRIPTION
## What & Why
Refs #160

After NSG and ufw fixes, curl still returns Connection refused — meaning the container crashes after starting. This step runs inside the VM (via az vm run-command) to expose docker ps, app logs, and localhost curl results directly in CI logs, revealing the root cause.

## Changes
- .github/workflows/ci-cd.yml — new 'Verify container health on VM' step after deploy

## How to test
Merge and run pipeline — check 'Verify container health on VM' step output for app logs / curl result